### PR TITLE
fix: remove size-by-density remark image feature

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -37,7 +37,6 @@ module.exports = themeOptions => {
               resolve: `gatsby-remark-images`,
               options: {
                 maxWidth: 1164,
-                sizeByPixelDensity: true,
                 linkImagesToOriginal: false,
                 tracedSVG: true,
               },


### PR DESCRIPTION
This prevents remark-image from shrinking photos that are blurry. This behavior is not ideal with lots of cards that need to be sized the same.