### PR TITLE
fix: console errors, code styles & card bug

### DIFF
--- a/packages/example/src/pages/components/DoDontExample.mdx
+++ b/packages/example/src/pages/components/DoDontExample.mdx
@@ -49,7 +49,7 @@ import { Row, Column, DoDontExample, Video } from 'gatsby-theme-carbon';
 <Column>
 <DoDontExample correct label="Productive moments are labeled in blue, and expressive moments are labeled in magenta.">
 
-<Video vimeoId="310583077" />
+<Video title="Video example" vimeoId="310583077" />
 
 </DoDontExample>
 </Column>

--- a/packages/gatsby-theme-carbon/src/components/AnchorLinks/anchor-links.scss
+++ b/packages/gatsby-theme-carbon/src/components/AnchorLinks/anchor-links.scss
@@ -44,7 +44,7 @@
     content: '\21B3'; //"↳"
     position: absolute;
     left: -$spacing-06;
-    font-family: IBM Plex Sans, ibm-plex-sans, Helvetica Neue, Arial, sans-serif;
+    font-family: $font-family;
     color: $interactive-02;
     transition: color $transition--base;
     cursor: pointer;

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.js
@@ -12,7 +12,7 @@ const { prefix } = settings;
 
 export default class Code extends React.Component {
   static propTypes = {
-    children: PropTypes.array,
+    children: PropTypes.node,
   };
 
   state = {

--- a/packages/gatsby-theme-carbon/src/components/Code/_code.scss
+++ b/packages/gatsby-theme-carbon/src/components/Code/_code.scss
@@ -1,26 +1,24 @@
 // Inline code
+code {
+  font-family: $font-family-mono;
+}
+
 p > code,
 li > code,
 td > code {
   @include reset;
+  @include carbon--type-style('code-01');
   position: relative;
   display: inline;
-  padding: rem(1px) $spacing-xs;
+  padding: rem(1px) $spacing-03;
   background: transparent;
   border-radius: 4px;
-  background-color: $carbon--gray-20;
-}
-
-td > code {
-  @include carbon--type-style('code-01');
-}
-
-p > code,
-li > code {
-  @include carbon--type-style('code-02');
+  background-color: $ui-03;
+  color: $text-01;
 }
 
 .#{$prefix}--snippet--website {
+  @include carbon--type-style('code-02');
   margin-bottom: $spacing-06;
 
   // 8 columns wide

--- a/packages/gatsby-theme-carbon/src/components/Code/_code.scss
+++ b/packages/gatsby-theme-carbon/src/components/Code/_code.scss
@@ -34,8 +34,9 @@ td > code {
   }
 }
 
-.#{$prefix}--snippet--website code {
+.#{$prefix}--snippet--website code pre {
   @include carbon--type-style('code-02');
+  font-family: $font-family-mono;
 }
 
 .#{$prefix}--snippet--website .#{$prefix}--snippet--single {

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -1,7 +1,7 @@
 .#{$prefix}--resource-card .#{$prefix}--tile {
   background: $ui-background;
   height: 100%;
-  padding: $spacing-05;
+  padding: $spacing-05 25% $spacing-05 $spacing-05;
   position: relative;
   transition: background $duration--fast-01;
   text-decoration: none;
@@ -18,7 +18,8 @@
 }
 
 .#{$prefix}--resource-card__subtitle {
-  @include carbon--type-style('body-short-02');
+  @include carbon--type-style('body-heading-01');
+  font-weight: 400;
   text-decoration: none;
   color: $text-01;
 }

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -18,7 +18,7 @@
 }
 
 .#{$prefix}--resource-card__subtitle {
-  @include carbon--type-style('body-heading-01');
+  @include carbon--type-style('heading-01');
   font-weight: 400;
   text-decoration: none;
   color: $text-01;

--- a/packages/gatsby-theme-carbon/src/styles/index.scss
+++ b/packages/gatsby-theme-carbon/src/styles/index.scss
@@ -38,6 +38,8 @@ $prefix: 'bx';
 @import '~@carbon/addons-website/scss/components/website-back-to-top-btn';
 
 $font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+$font-family-mono: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono',
+  'Bitstream Vera Sans Mono', Courier, monospace;
 
 //---------------------------------------
 // Page styles


### PR DESCRIPTION
ref #43
closes #40

- fix do-don't example error
- updates code snippet styles, was missing font and default text color so looked broken on dark background in the footer. 
- fix ResourceCard style bugs

Not fixed
```
Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `CodeSnippet`, expected `string`.
```

