### PR TITLE
fix: don't render next/prev for floating pages

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Main.js
+++ b/packages/gatsby-theme-carbon/src/components/Main.js
@@ -4,6 +4,7 @@ import { Grid } from './Grid';
 const Main = styled(Grid)`
   padding-top: ${props => (props.padded ? '80px' : 0)};
   padding-bottom: 80px;
+  min-height: calc(100vh - 40rem);
 `;
 
 export default Main;

--- a/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.js
+++ b/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.js
@@ -164,10 +164,13 @@ const NextPreviousContainer = props => {
     return {}; // final page
   };
 
-  const previousItem = getPreviousItem();
-  const nextItem = getNextItem();
+  if (currentTitle !== 'Home' && !navigationList[navIndex]) {
+    return null;
+  }
 
-  return <NextPrevious previousItem={previousItem} nextItem={nextItem} />;
+  return (
+    <NextPrevious previousItem={getPreviousItem()} nextItem={getNextItem()} />
+  );
 };
 
 export default NextPreviousContainer;


### PR DESCRIPTION
chore: This allows for pages to be generated without existing in the nav config. These floating pages should be avoided for UX and SEO discoverability, but we don't want to break the build of something is left out or intentionally excluded
