### PR TITLE
fix(featureCard): update mobile breakpoint styles

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/FeatureCard/feature-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeatureCard/feature-card.scss
@@ -4,6 +4,8 @@
 
 .#{$prefix}--feature-card__row {
   @include carbon--breakpoint('md') {
+    margin-left: -1rem;
+    margin-right: -1rem;
     position: absolute;
     bottom: 0;
     right: 0;

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -1,8 +1,3 @@
-.#{$prefix}--feature-card__row {
-  margin-left: -1rem;
-  margin-right: -1rem;
-}
-
 .#{$prefix}--resource-card .#{$prefix}--tile {
   background: $ui-background;
   height: 100%;


### PR DESCRIPTION
Fix for mis-alignment at mobile breakpoint. Also moves styles into correct sass file 🤦‍♀ 

![image](https://user-images.githubusercontent.com/2753488/58126270-38f14880-7bd8-11e9-84a9-415862756ab9.png)
