### PR TITLE
fix: max-width for images and dodont spacing

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
@@ -1,6 +1,6 @@
 // Example
 .#{$prefix}--example {
-  margin-bottom: $spacing-06;
+  margin-bottom: $spacing-07;
   width: 100%;
 }
 

--- a/packages/gatsby-theme-carbon/src/styles/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/_page.scss
@@ -103,6 +103,10 @@ button {
 }
 
 // images
+img {
+  max-width: 100%;
+}
+
 .gatsby-resp-image-wrapper {
   margin-bottom: $spacing-06;
 }


### PR DESCRIPTION
couple small styling issues I noticed working on IDL site

- need the max width for images for larger gif and svg images
- had the bottom padding wrong for do-dont