### PR TITLE
Feature card update

### DIFF
--- a/packages/example/src/pages/components/FeatureCard.mdx
+++ b/packages/example/src/pages/components/FeatureCard.mdx
@@ -24,6 +24,18 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
 
 </FeatureCard>
 
+<FeatureCard
+  subTitle="With subtitle"
+  title="Title"
+  actionIcon="arrowRight"
+  href="/"
+  color="dark"
+  >
+
+![smart work](/images/smart-work.png)
+
+</FeatureCard>
+
 ## Code
 
 ```

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -57,6 +57,9 @@ module.exports = themeOptions => {
                 maxWidth: 1170,
                 linkImagesToOriginal: false,
                 quality: 75,
+                withWebp: {
+                  quality: 100,
+                },
               },
             },
             { resolve: `gatsby-remark-responsive-iframe` },

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -54,9 +54,9 @@ module.exports = themeOptions => {
             {
               resolve: `gatsby-remark-images`,
               options: {
-                maxWidth: 1184,
+                maxWidth: 1170,
                 linkImagesToOriginal: false,
-                tracedSVG: true,
+                quality: 75,
               },
             },
             { resolve: `gatsby-remark-responsive-iframe` },

--- a/packages/gatsby-theme-carbon/src/components/FeatureCard/FeatureCard.js
+++ b/packages/gatsby-theme-carbon/src/components/FeatureCard/FeatureCard.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'gatsby';
+import { settings } from 'carbon-components';
 import { Row, Column } from '../Grid';
 import ResourceCard from '../ResourceCard';
-import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 

--- a/packages/gatsby-theme-carbon/src/components/FeatureCard/feature-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeatureCard/feature-card.scss
@@ -21,10 +21,7 @@
 
 .#{$prefix}--feature-card__img {
   position: relative;
-  margin-left: -1px;
-  margin-right: -1px;
 }
-
 .#{$prefix}--feature-card:hover
   .#{$prefix}--feature-card__link
   .#{$prefix}--tile {
@@ -70,6 +67,7 @@
     width: auto !important;
     left: auto !important;
     right: 0;
+    object-fit: cover;
   }
 }
 


### PR DESCRIPTION
## Fixed
* pixel sliver for some images, 
* image distortion on mobile
* over-aggressive image compression
* add webp support for browsers that allow it (chrome, firefox, edge)


### sliver

![sliver](https://user-images.githubusercontent.com/4078018/58668134-9d5d8780-82fd-11e9-97ed-f01aeb58e64b.png)

### Image distortion


This changes the image's default `object-fit` to cover rather than stretch/distort.

In the future, `object-position` can be added to allow for controlling the piece of the visible image (top/bottom/left/right/center). In the mean time, devs can control this property with their own styling solutions.

#### Before
![Screenshot_2019-05-30 Gatsby Theme Carbon(3)](https://user-images.githubusercontent.com/4078018/58668429-7b183980-82fe-11e9-8019-f50b8f0bcfb7.png)

#### After
![Screenshot_2019-05-30 Gatsby Theme Carbon(2)](https://user-images.githubusercontent.com/4078018/58667467-b9602980-82fb-11e9-8435-a5b8ae774b04.png)

### Compression

#### Before (`quality: 50`, 82kb)
![50](https://user-images.githubusercontent.com/4078018/58668285-18bf3900-82fe-11e9-8bc9-0a43a8d1f9c3.png)

#### After (`quality: 75`, 356kb)

![75](https://user-images.githubusercontent.com/4078018/58668051-5f606380-82fd-11e9-83b8-804a7623af25.png)


