### PR TITLE
chore: remove unused config

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -19,8 +19,7 @@ module.exports = {
     {
       resolve: 'gatsby-theme-carbon',
       options: {
-        name: 'Gatsby Theme Carbon Starter',
-        shortName: 'Carbon Starter',
+        additionalFontWeights: [200],
       },
     },
   ],


### PR DESCRIPTION
Removes the old way of passing manifest options as theme options. We'd rather folks just pass it directly instead of currying it.