### PR TITLE
fix: italic plex and scrolling page tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ siteMetadata: {
 
 ### Additional font weights
 
-If needed, you can add support for additional Plex font weights
+If needed, you can add support for additional Plex font weights. Don't forget to specify italics for the additional weights if needed.
 
 ```js
 __experimentalThemes: [
@@ -110,7 +110,7 @@ __experimentalThemes: [
       resolve: 'gatsby-theme-carbon',
       options: {
 		// will get added to default [300, 400, 600]
-        additionalFontWeights: [200]
+        additionalFontWeights: ['200', '200i]
       },
     },
   ],

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       resolve: 'gatsby-theme-carbon',
       options: {
-        additionalFontWeights: [200],
+        additionalFontWeights: ['200', '200i'],
       },
     },
   ],

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -23,7 +23,15 @@ module.exports = themeOptions => {
           fonts: [
             {
               family: `IBM Plex Sans`,
-              variants: [300, 400, 600, ...additionalFontWeights],
+              variants: [
+                300,
+                '300i',
+                400,
+                '400i',
+                600,
+                '600i',
+                ...additionalFontWeights,
+              ],
             },
             {
               family: `IBM Plex Mono`,

--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
@@ -14,6 +14,8 @@
   width: 100%;
   list-style: none;
   padding: 0;
+  overflow-x: scroll;
+  scrollbar-width: none;
 }
 
 .list-item {

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -30,6 +30,10 @@
   left: 1rem;
   width: 32px;
   height: 32px;
+
+  // Allows for variable-height icons
+  display: flex;
+  align-items: flex-end;
 }
 
 .#{$prefix}--resource-card__icon--action {

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -30,10 +30,6 @@
   left: 1rem;
   width: 32px;
   height: 32px;
-
-  // Allows for variable-height icons
-  display: flex;
-  align-items: flex-end;
 }
 
 .#{$prefix}--resource-card__icon--action {


### PR DESCRIPTION
Devs need to specify italic variants if they're needed. Documentation
added. closes #135, closes #134