### PR TITLE
fix(page-tabs): set overflow-x to auto

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
@@ -14,7 +14,7 @@
   width: 100%;
   list-style: none;
   padding: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   scrollbar-width: none;
 }
 


### PR DESCRIPTION
Resolves #145

Prevents horizontal scrollbar (or the "space" for the scrollbar) always showing even when the page tabs aren't overflowing their container.