### PR TITLE
chore: add ai to the switcher link

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ export default Custom404;
 
 ### Image Compression
 
-Leveraging gatsby-image requires you to provide full resolution, quality images. This is _especially_ true when the image is a photo rather than an illustration. The compression plugin falters for large images with relatively low pixel density. Full resolution photos from unsplash, IBM Digital assets, etc. routinely run 7-10mb. It's possible to over-ride the default quality of the gatsby plugin. But our _strong_ recommendation would be to use higher quality source images and let gatsby-image really do it's magic with image optimization.
-
-If higher resolution is not an option, you can add the following to your gatsby-config and tweak the default optimization to your performance/quality needs:
+You can enable WebP by passing `withWebp: true` or providing your own optimization level. See the gatsby-remark-images [plugin options](https://www.gatsbyjs.org/packages/gatsby-remark-images/#options).
 
 ```js
 module.exports = {
@@ -174,11 +172,9 @@ module.exports = {
       options: {
         name: 'Gatsby Theme Carbon Starter',
         shortName: 'Carbon Starter',
+        withWebp: true,
       },
     },
-  ],
-  plugins: [
-    { resolve: `gatsby-plugin-sharp`, options: { defaultQuality: 80 } },
   ],
 };
 ```

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = themeOptions => {
   const {
     additionalFontWeights = [],
     isSearchEnabled = false,
-    isWebPEnabled = false,
+    withWebp = false,
   } = themeOptions;
 
   return {
@@ -63,7 +63,7 @@ module.exports = themeOptions => {
                 maxWidth: 1170,
                 linkImagesToOriginal: false,
                 quality: 75,
-                withWebp: isWebPEnabled,
+                withWebp,
               },
             },
             { resolve: `gatsby-remark-responsive-iframe` },

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -2,7 +2,11 @@ const path = require('path');
 const colors = require('@carbon/themes');
 
 module.exports = themeOptions => {
-  const { additionalFontWeights = [], isSearchEnabled = false } = themeOptions;
+  const {
+    additionalFontWeights = [],
+    isSearchEnabled = false,
+    isWebPEnabled = false,
+  } = themeOptions;
 
   return {
     siteMetadata: {
@@ -59,9 +63,7 @@ module.exports = themeOptions => {
                 maxWidth: 1170,
                 linkImagesToOriginal: false,
                 quality: 75,
-                withWebp: {
-                  quality: 100,
-                },
+                withWebp: isWebPEnabled,
               },
             },
             { resolve: `gatsby-remark-responsive-iframe` },

--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -65,7 +65,7 @@ const DefaultChildren = () => (
     <SwitcherLink href="https://www.ibm.com/services/ibmix/">
       IBM iX
     </SwitcherLink>
-    <SwitcherLink disabled>IBM AI</SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/design/ai">IBM AI</SwitcherLink>
   </>
 );
 


### PR DESCRIPTION
WebP is now disabled by default but can be enabled by turning on the config.