### PR TITLE
fix: various small fixes (Aside, DoDont & switcher icons)

### DIFF
--- a/packages/example/src/pages/components/DoDontExample.mdx
+++ b/packages/example/src/pages/components/DoDontExample.mdx
@@ -11,7 +11,7 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 ## Example
 
 <Row>
-<Column colMd={3} colLg={3}>
+<Column colMd={4} colLg={4}>
 
 #### Image
 
@@ -21,13 +21,15 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 
 </DoDontExample>
 </Column>
-<Column colMd={3} colLg={3}>
+<Column colMd={4} colLg={4}>
 
 #### Text
 
 <DoDontExample type="dont" aspectRatio="1:1"  color="dark" captionTitle="Caption title" caption="Caption" text="This is some text"></DoDontExample>
 </Column>
-<Column colMd={3} colLg={3}>
+</Row>
+<Row>
+<Column colLg={8}>
 
 #### Video
 

--- a/packages/gatsby-theme-carbon/src/components/Aside/aside.scss
+++ b/packages/gatsby-theme-carbon/src/components/Aside/aside.scss
@@ -2,6 +2,7 @@
   @include carbon--type-style('body-long-01');
   position: relative;
   padding-top: $spacing-04;
+  top: -$spacing-04;
 }
 
 .#{$prefix}--aside:before {

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.js
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.js
@@ -56,7 +56,6 @@ const Header = ({ children, shouldHideHeader }) => {
           <HeaderGlobalAction
             className={cx({
               [icon]: true,
-           
             })}
             aria-label="Switch"
             onClick={() => {

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.js
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.js
@@ -18,7 +18,7 @@ import GlobalSearch from '../GlobalSearch';
 import NavContext from '../../util/context/NavContext';
 import useMetadata from '../../util/hooks/useMetadata';
 
-import { hidden, header } from './Header.module.scss';
+import { hidden, header, icon } from './Header.module.scss';
 
 const Header = ({ children, shouldHideHeader }) => {
   const { leftNavIsOpen, toggleNavState, switcherIsOpen } = useContext(
@@ -54,7 +54,10 @@ const Header = ({ children, shouldHideHeader }) => {
         <HeaderGlobalBar>
           {isSearchEnabled && <GlobalSearch />}
           <HeaderGlobalAction
-            className="bx--header__action--switcher"
+            className={cx({
+              [icon]: true,
+           
+            })}
             aria-label="Switch"
             onClick={() => {
               toggleNavState('switcherIsOpen');

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -11,3 +11,7 @@ header.header {
 .header.hidden {
   top: -48px;
 }
+
+.icon svg {
+  margin-top: 2px;
+}

--- a/packages/gatsby-theme-carbon/src/components/markdown/markdown.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/markdown.scss
@@ -4,19 +4,22 @@
 .#{$prefix}--paragraph {
   @include carbon--type-style('body-long-02');
   margin-bottom: $spacing-06;
-  padding-right: $spacing-05;
+  padding-right: $spacing-07;
 }
 
 // Responsive by default
 .#{$prefix}--paragraph--responsive {
+  margin-left: -$spacing-05;
+  padding-left: $spacing-05;
+
   // 5 columns wide
   @include carbon--breakpoint('md') {
-    width: calc(62.5% - 2rem);
+    width: calc(63%);
   }
 
   // 8 columns wide
   @include carbon--breakpoint('lg') {
-    width: calc(66.667% - 2rem);
+    width: calc(67.3%);
   }
 }
 


### PR DESCRIPTION
- Fix alignment for aside closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/151
- Update do-dont demo to be correct size closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/141
- Fixes alignment of switcher/close icons closes #142
- Fixes paragraph alignment/spacing on grid closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/99