### PR TITLE
fix(DoDont): fix for images that aren't square or are smaller

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
@@ -21,6 +21,7 @@
 
 .#{$prefix}--example__content img {
   margin-bottom: 0;
+  width: 100%;
 }
 
 .#{$prefix}--example-card {


### PR DESCRIPTION
Makes sure images span full width of DoDont example card. (noticed when using a svg inside the example that was smaller)