### PR TITLE
fix: remove margin-top for first-of-type headings in main grid container

### DIFF
--- a/packages/gatsby-theme-carbon/src/styles/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/_page.scss
@@ -29,11 +29,11 @@ body {
     padding-left: 400px;
   }
 
-  > h2:first-of-type,
-  > h3:first-of-type,
-  > h4:first-of-type,
-  > h5:first-of-type,
-  > h6:first-of-type {
+  > h2:first-child,
+  > h3:first-child,
+  > h4:first-child,
+  > h5:first-child,
+  > h6:first-child {
     margin-top: 0;
   }
 }

--- a/packages/gatsby-theme-carbon/src/styles/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/_page.scss
@@ -29,7 +29,6 @@ body {
     padding-left: 400px;
   }
 
-  > h1:first-of-type,
   > h2:first-of-type,
   > h3:first-of-type,
   > h4:first-of-type,

--- a/packages/gatsby-theme-carbon/src/styles/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/_page.scss
@@ -28,6 +28,15 @@ body {
   @include carbon--breakpoint('max') {
     padding-left: 400px;
   }
+
+  > h1:first-of-type,
+  > h2:first-of-type,
+  > h3:first-of-type,
+  > h4:first-of-type,
+  > h5:first-of-type,
+  > h6:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .container .#{$prefix}--col-no-gutter {


### PR DESCRIPTION
Resolves #147

We were seeing too much padding on some of our pages that start with a heading, specifically an `h2`. So this rule should remove that in the heading is the first direct descendent of the main `bx--grid` class for a page 🤔 

I remove `h1` since `margin-top` is removed elsewhere. I could remove `h3` - `h6` if you want. I just included them just in case 😅 