### PR TITLE
fix: use remark to generate slugs per page

### DIFF
--- a/packages/example/src/pages/components/AnchorLinks.mdx
+++ b/packages/example/src/pages/components/AnchorLinks.mdx
@@ -50,9 +50,16 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
 </AnchorLinks>
 ```
 
-## Props
+### `AnchorLinks` Props
 
 | property | propType | required | default | description             |
 | -------- | -------- | -------- | ------- | ----------------------- |
 | children | node     |          |         |                         |
 | small    | bool     |          |         | Display small font size |
+
+### `AnchorLink` Props
+
+| property | propType | required | default        | description                                                                                              |
+| -------- | -------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------- |
+| children | node     |          |                |                                                                                                          |
+| to       | string   |          | props.children | By default, the `AnchorLink` slugifys the children you pass in. Use the to prop to override this target. |

--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -6,11 +6,13 @@ title: Markdown
 
 These are the built in components that you'll have access to simply by using markdown. The whitespace around these components **is significant**. If you encounter any errors, make sure you format the markdown and surounding space properly.
 
+For most pages, we recommend starting with a `PageDescription` followed by `AnchorLinks` if the content is long enough.
+
 </PageDescription>
 
 <AnchorLinks>
   <AnchorLink>Text decoration</AnchorLink>
-  <AnchorLink to="#h1">Headers</AnchorLink>
+  <AnchorLink>Headers</AnchorLink>
   <AnchorLink>Lists</AnchorLink>
   <AnchorLink>Links</AnchorLink>
   <AnchorLink>Images</AnchorLink>

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const colors = require('@carbon/themes');
+const remarkSlug = require('remark-slug');
 
 module.exports = themeOptions => {
   const {
@@ -68,6 +69,7 @@ module.exports = themeOptions => {
             { resolve: `gatsby-remark-responsive-iframe` },
             { resolve: `gatsby-remark-copy-linked-files` },
           ],
+          remarkPlugins: [remarkSlug],
           defaultLayouts: {
             default: require.resolve('./src/templates/Default.js'),
             home: require.resolve('./src/templates/Homepage.js'),

--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -52,12 +52,12 @@
     "gatsby-remark-unwrap-images": "^1.0.1",
     "gatsby-source-filesystem": "^2.0.37",
     "gatsby-transformer-yaml": "^2.1.12",
-    "github-slugger": "^1.2.1",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.11.0",
     "prop-types": "^15.7.2",
     "react-helmet": "^6.0.0-beta",
+    "remark-slug": "^5.1.2",
     "slugify": "^1.3.4",
     "smooth-scroll": "^16.0.3"
   }

--- a/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLink.js
+++ b/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLink.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import GHSlugger from 'github-slugger';
+import slugify from 'slugify';
 import { link } from './AnchorLinks.module.scss';
 
-const slugger = new GHSlugger();
-
 const AnchorLink = ({ to, children }) => {
-  const href = to || `#${slugger.slug(children)}`;
+  const href = to || `#${slugify(children, { lower: true })}`;
   return (
     <a className={link} href={href}>
       {children}

--- a/packages/gatsby-theme-carbon/src/components/AutolinkHeader/AutolinkHeader.js
+++ b/packages/gatsby-theme-carbon/src/components/AutolinkHeader/AutolinkHeader.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import GHSlugger from 'github-slugger';
 import Link from '@carbon/icons-react/lib/link/20';
 import cx from 'classnames';
 
 import { header, anchor } from './AutolinkHeader.module.scss';
-
-const slugger = new GHSlugger();
 
 const Anchor = ({ id, string }) => (
   <a className={anchor} href={`#${id}`} aria-label={`${string} permalink`}>
@@ -13,18 +10,14 @@ const Anchor = ({ id, string }) => (
   </a>
 );
 
-const AutolinkHeader = ({ is: Component, ...props }) => {
+const AutolinkHeader = ({ is: Component, id, className, ...props }) => {
   const string = React.Children.map(
     props.children,
     child => (child.props ? child.props.children : child) // handle bold/italic words
   ).join('');
 
-  const id = slugger.slug(string);
-
-  const className = cx(header, props.className);
-
   return (
-    <Component {...props} id={id} className={className}>
+    <Component id={id} className={cx(header, className)} {...props}>
       <Anchor id={id} string={string} />
       {props.children}
     </Component>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7041,7 +7041,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-github-slugger@^1.2.1:
+github-slugger@^1.0.0, github-slugger@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"
   integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==
@@ -9414,6 +9414,11 @@ mdast-util-to-nlcst@^3.2.0:
     repeat-string "^1.5.2"
     unist-util-position "^3.0.0"
     vfile-location "^2.0.0"
+
+mdast-util-to-string@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.6.tgz#7d85421021343b33de1552fc71cb8e5b4ae7536d"
+  integrity sha512-868pp48gUPmZIhfKrLbaDneuzGiw3OTDjHc5M1kAepR2CWBJ+HpEsm252K4aXdiP5coVZaJPOqGtVU6Po8xnXg==
 
 mdast-util-to-string@^1.0.4, mdast-util-to-string@^1.0.5:
   version "1.0.5"
@@ -12220,6 +12225,15 @@ remark-retext@^3.1.2:
   integrity sha512-+48KzJdSXvsPupY5pj5AY7oBUSiDOqFPZBKebX5WemrMyIG+RImIt9hgeqelluVDd1kooHen33K/aybTPyoI9g==
   dependencies:
     mdast-util-to-nlcst "^3.2.0"
+
+remark-slug@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-5.1.2.tgz#715ecdef8df1226786204b1887d31ab16aa24609"
+  integrity sha512-DWX+Kd9iKycqyD+/B+gEFO3jjnt7Yg1O05lygYSNTe5i5PIxxxPjp5qPBDxPIzp5wreF7+1ROCwRgjEcqmzr3A==
+  dependencies:
+    github-slugger "^1.0.0"
+    mdast-util-to-string "^1.0.0"
+    unist-util-visit "^1.0.0"
 
 remark-squeeze-paragraphs@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
`remark-slug` handles resetting the slugger per page generation