### PR TITLE
fix: update caption widths

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
+++ b/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
@@ -17,14 +17,14 @@ img + .#{$prefix}--caption {
 
 // Responsive by default
 .#{$prefix}--caption--responsive {
-  // 4 columns wide
+  // 6/8 columns
   @include carbon--breakpoint('md') {
-    width: 50%;
+    width: 75%;
   }
 
-  // 4 columns wide
+  // 6/12 columns wide
   @include carbon--breakpoint('lg') {
-    width: 33.333%;
+    width: 50%;
   }
 }
 


### PR DESCRIPTION
closes #190 

Brings caption styles in line with dl/carbon.

Captions should match paragraphs at sm/md breakpoints, but max out at 6/12 columns for lg breakpoint.