### PR TITLE
fix: remove incorrect prop from ArticleCard docs

### DIFF
--- a/packages/example/src/pages/components/ArticleCard.mdx
+++ b/packages/example/src/pages/components/ArticleCard.mdx
@@ -177,17 +177,16 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
 
 ## Props
 
-| property    | propType | required | default  | description                                                                                         |
-| ----------- | -------- | -------- | -------- | --------------------------------------------------------------------------------------------------- |
-| children    | node     |          |          | Use 32x32 image as child, will display in bottom left of card                                       |
-| href        | string   |          |          | Set url for card                                                                                    |
-| title       | string   |          |          | Card title                                                                                          |
-| subTitle    | string   |          |          | Card smaller sub title                                                                              |
-| author      | string   |          |          | Author of article                                                                                   |
-| date        | string   |          |          | Date article published                                                                              |
-| readTime    | string   |          |          | Read time of article                                                                                |
-| actionIcon  | string   |          | `launch` | Action icon, default is launch, options are `Launch`, `ArrowRight`, `Download`, `Disabled`, `Email` |
-| aspectRatio | string   |          | 2:1      | Set card aspect ratio, default is 2:1, options are 1:1, 16:9, 4:3                                   |
-| color       | string   |          | light    | Set to `dark` for dark background                                                                   |
-| disabled    | bool     |          | false    | Set for disabled card                                                                               |
-| className   | string   |          |          | Add custom class name                                                                               |
+| property   | propType | required | default  | description                                                                                         |
+| ---------- | -------- | -------- | -------- | --------------------------------------------------------------------------------------------------- |
+| children   | node     |          |          | Use 32x32 image as child, will display in bottom left of card                                       |
+| href       | string   |          |          | Set url for card                                                                                    |
+| title      | string   |          |          | Card title                                                                                          |
+| subTitle   | string   |          |          | Card smaller sub title                                                                              |
+| author     | string   |          |          | Author of article                                                                                   |
+| date       | string   |          |          | Date article published                                                                              |
+| readTime   | string   |          |          | Read time of article                                                                                |
+| actionIcon | string   |          | `launch` | Action icon, default is launch, options are `Launch`, `ArrowRight`, `Download`, `Disabled`, `Email` |
+| color      | string   |          | light    | Set to `dark` for dark background                                                                   |
+| disabled   | bool     |          | false    | Set for disabled card                                                                               |
+| className  | string   |          |          | Add custom class name                                                                               |


### PR DESCRIPTION
closes #214 

ArticleCard docs incorrectly lists aspectRatio as a prop, this removes it from the docs