### PR TITLE
fix: accordion styles

### DIFF
--- a/packages/example/src/pages/components/Accordion.mdx
+++ b/packages/example/src/pages/components/Accordion.mdx
@@ -10,14 +10,6 @@ The `<Accordion>` and `<AccordionItem>` components are used together to display 
 
 ## Example
 
-<Row>
-<Column colMd={4} colLg={8}>
-
-![Grid Example](images/Article_05.png)
-
-</Column>
-</Row>
-
 <Accordion>
 <AccordionItem title="Title 1">
 

--- a/packages/example/src/pages/components/Accordion.mdx
+++ b/packages/example/src/pages/components/Accordion.mdx
@@ -18,15 +18,6 @@ The `<Accordion>` and `<AccordionItem>` components are used together to display 
 </Column>
 </Row>
 
-In ac nisi ut mauris venenatis blandit a et ante. Mauris eu congue velit, eget dictum diam. Etiam sed turpis quis ligula interdum lobortis eu et libero. Praesent nec eros sit amet elit tempor egestas cursus non nulla. Vestibulum dictum luctus lorem in rhoncus. 
-
-Nullam vestibulum blandit libero, ac tempus felis tristique id. Aliquam rhoncus vestibulum dui eu dictum. Morbi congue purus eu libero sodales, nec sollicitudin ligula tempor.
-
-- list item
-- list item
-- list item
-
-
 <Accordion>
 <AccordionItem title="Title 1">
 

--- a/packages/example/src/pages/components/Accordion.mdx
+++ b/packages/example/src/pages/components/Accordion.mdx
@@ -10,8 +10,35 @@ The `<Accordion>` and `<AccordionItem>` components are used together to display 
 
 ## Example
 
+<Row>
+<Column colMd={4} colLg={8}>
+
+![Grid Example](images/Article_05.png)
+
+</Column>
+</Row>
+
+In ac nisi ut mauris venenatis blandit a et ante. Mauris eu congue velit, eget dictum diam. Etiam sed turpis quis ligula interdum lobortis eu et libero. Praesent nec eros sit amet elit tempor egestas cursus non nulla. Vestibulum dictum luctus lorem in rhoncus. 
+
+Nullam vestibulum blandit libero, ac tempus felis tristique id. Aliquam rhoncus vestibulum dui eu dictum. Morbi congue purus eu libero sodales, nec sollicitudin ligula tempor.
+
+- list item
+- list item
+- list item
+
+
 <Accordion>
-  <AccordionItem title="Title 1">Content Section</AccordionItem>
+<AccordionItem title="Title 1">
+
+In ac nisi ut mauris venenatis blandit a et ante. Mauris eu congue velit, eget dictum diam. Etiam sed turpis quis ligula interdum lobortis eu et libero. Praesent nec eros sit amet elit tempor egestas cursus non nulla. Vestibulum dictum luctus lorem in rhoncus. 
+
+Nullam vestibulum blandit libero, ac tempus felis tristique id. Aliquam rhoncus vestibulum dui eu dictum. Morbi congue purus eu libero sodales, nec sollicitudin ligula tempor.
+
+- list item
+- list item
+- list item
+
+</AccordionItem>
   <AccordionItem title="Title 2">Content Section</AccordionItem>
   <AccordionItem title="Title 3">Content Section</AccordionItem>
 </Accordion>

--- a/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
+++ b/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
@@ -6,7 +6,7 @@ import { Row, Grid, Column } from '../Grid';
 
 const Accordion = ({ className, ...rest }) => (
   <Row>
-    <Column colLg={8} colMd={6}>
+    <Column colLg={8}>
       <CarbonAccordion {...rest} className={cx(className, accordion)} />
     </Column>
   </Row>

--- a/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
+++ b/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
@@ -2,8 +2,13 @@ import React from 'react';
 import cx from 'classnames';
 import { Accordion as CarbonAccordion } from 'carbon-components-react';
 import { accordion } from './Accordion.module.scss';
+import { Row, Grid, Column } from '../Grid';
 
 const Accordion = ({ className, ...rest }) => (
-  <CarbonAccordion {...rest} className={cx(className, accordion)} />
+  <Row>
+    <Column colLg={8} colMd={6}>
+      <CarbonAccordion {...rest} className={cx(className, accordion)} />
+    </Column>
+  </Row>
 );
 export default Accordion;

--- a/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
+++ b/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { Accordion as CarbonAccordion } from 'carbon-components-react';
 import { accordion } from './Accordion.module.scss';
-import { Row, Grid, Column } from '../Grid';
+import { Row, Column } from '../Grid';
 
 const Accordion = ({ className, ...rest }) => (
   <Row>

--- a/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.module.scss
@@ -2,16 +2,19 @@
   @import '~carbon-components/scss/components/accordion/accordion';
 }
 
-.accordion {
-  width: 100%;
-  @include carbon--breakpoint('md') {
-    width: 75%;
-  }
-  @include carbon--breakpoint('lg') {
-    width: 58.33%;
-  }
+.accordion :global(.bx--accordion__content p) {
+  @include carbon--type-style('body-long-02');
+}
+
+.accordion :global(.bx--accordion__content) {
+  padding-right: 0;
+}
+
+.accordion :global(.bx--accordion__heading) {
+  padding-top: $spacing-04;
+  padding-bottom: $spacing-04;
 }
 
 .accordion :global(.bx--accordion__title) {
-  font-weight: bold;
+  @include carbon--type-style('heading-02');
 }


### PR DESCRIPTION
Closes #251 

- Updated example to add paragraphs and lists as children
- Added our grid component instead of trying to fake it with % which ends up slightly off-grid
- Updated font size styles for website specific rules based on Mike's comments in the issue

FYI @sstrubberg