### PR TITLE
260 Updates component codeblock examples with new features 

### DIFF
--- a/packages/example/src/pages/components/Accordion.mdx
+++ b/packages/example/src/pages/components/Accordion.mdx
@@ -18,7 +18,7 @@ The `<Accordion>` and `<AccordionItem>` components are used together to display 
 
 ## Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Accordion
+```jsx path=components/Accordion/Accordion.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Accordion
 <Accordion>
   <AccordionItem title="Title 1">Content Section</AccordionItem>
   <AccordionItem title="Title 2">Content Section</AccordionItem>

--- a/packages/example/src/pages/components/AnchorLinks.mdx
+++ b/packages/example/src/pages/components/AnchorLinks.mdx
@@ -32,7 +32,7 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
 
 #### Normal
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/AnchorLinks
+```jsx path=components/AnchorLinks/AnchorLinks.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/AnchorLinks
 <AnchorLinks>
   <AnchorLink>Link 1</AnchorLink>
   <AnchorLink>Link 2</AnchorLink>
@@ -42,7 +42,7 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
 
 #### Small
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/AnchorLinks
+```jsx path=components/AnchorLinks/AnchorLinks.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/AnchorLinks
 <AnchorLinks small>
   <AnchorLink>Small link 1</AnchorLink>
   <AnchorLink>Small link 2</AnchorLink>

--- a/packages/example/src/pages/components/ArticleCard.mdx
+++ b/packages/example/src/pages/components/ArticleCard.mdx
@@ -92,7 +92,7 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
 
 ## Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ArticleCard
+```jsx path=components/ArticleCard/ArticleCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ArticleCard
 <Row>
   <Column colMd={4} colLg={4} noGutterMdLeft>
     <ArticleCard

--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -36,7 +36,7 @@ What we borrow from our own design history is not a mid-century aesthetic in sty
 
 ## Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Aside
+```jsx path=components/Aside/Aside.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Aside
 <Column colSm={0} colMd={2} colLg={3} offsetMd={1} noGutterSm>
   <Aside>
     **Good design is always good design.** What we borrow from our own design

--- a/packages/example/src/pages/components/Caption.mdx
+++ b/packages/example/src/pages/components/Caption.mdx
@@ -41,12 +41,11 @@ The `<Caption>` component is typically used below images or videos. They will de
 
 #### Full-width
 
-```
+```jsx path=components/Caption/Caption.js src= https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Caption
 <Caption fullWidth>
   This is a full width caption. With this prop, the caption's width will be 100%
   so it will fill its container.
 </Caption>
-
 ```
 
 ## Props

--- a/packages/example/src/pages/components/Caption.mdx
+++ b/packages/example/src/pages/components/Caption.mdx
@@ -32,7 +32,7 @@ The `<Caption>` component is typically used below images or videos. They will de
 
 #### Normal
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Caption
+```jsx path=components/Caption/Caption.js src= https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Caption
 <Caption>
   This is a regular caption. It will attempt to respond to it's container
   element appropriately.

--- a/packages/example/src/pages/components/DoDontExample.mdx
+++ b/packages/example/src/pages/components/DoDontExample.mdx
@@ -45,7 +45,7 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 
 #### Image
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
+```jsx path=components/DoDontExample/DoDontExample.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
 <DoDontExample type="do" captionTitle="Caption title" caption="Caption">
   ![Alt text](images/light-theme.png)
 </DoDontExample>
@@ -53,7 +53,7 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 
 #### Text
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
+```jsx path=components/DoDontExample/DoDontExample.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
 <DoDontExample
   type="dont"
   aspectRatio="1:1"
@@ -66,7 +66,7 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 
 #### Video
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
+```jsx path=components/DoDontExample/DoDontExample.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
 <DoDontExample type="do" caption="Caption" captionTitle="Caption title">
   <Video vimeoId="310583077" />
 </DoDontExample>

--- a/packages/example/src/pages/components/FeatureCard.mdx
+++ b/packages/example/src/pages/components/FeatureCard.mdx
@@ -36,7 +36,7 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
 
 ## Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/FeatureCard
+```jsx path=components/FeatureCard/FeatureCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/FeatureCard
 <FeatureCard
   subTitle="With subtitle"
   title="Title"

--- a/packages/example/src/pages/components/Grid.mdx
+++ b/packages/example/src/pages/components/Grid.mdx
@@ -28,7 +28,7 @@ The `<Grid>` component is a wrapper that adds the `bx--grid` class to a wrapper 
 
 ### Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Grid>
   <Row>
     <Column>Contents</Column>
@@ -53,7 +53,7 @@ The `<Row>` component is a wrapper that adds the `bx--row` class to a wrapper di
 
 ### Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Row>
   <Column>
     Content or additional <Components />
@@ -153,7 +153,7 @@ The `<Column>` component is used to define column widths for your content, you c
 
 ### Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Row>
   <Column colMd={4} colLg={4}>
     ![Grid Example](images/Article_05.png)
@@ -169,7 +169,7 @@ The `<Column>` component is used to define column widths for your content, you c
 
 #### No gutter left
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Row>
   <Column colMd={4} colLg={4} noGutterMdLeft>
     ![Grid Example](images/Article_05.png)
@@ -185,7 +185,7 @@ The `<Column>` component is used to define column widths for your content, you c
 
 #### No gutter
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Row>
   <Column colMd={4} colLg={4} noGutterSm>
     ![Grid Example](images/Article_05.png)
@@ -201,7 +201,7 @@ The `<Column>` component is used to define column widths for your content, you c
 
 #### Offset
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
+```jsx path=components/Grid.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Grid
 <Row>
   <Column colMd={4} colLg={4} offsetLg={4}>
     ![Grid Example](images/Article_05.png)

--- a/packages/example/src/pages/components/ImageCard.mdx
+++ b/packages/example/src/pages/components/ImageCard.mdx
@@ -74,7 +74,7 @@ The `<ImageCard>` component should generally be used inside of a `<Row>` and `<C
 
 ## Code
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ImageCard
+```jsx path=components/ImageCard/ImageCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ImageCard
 <Row className="image-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ImageCard title="Title" subTitle="Subtitle" href="/">

--- a/packages/example/src/pages/components/PageDescription.mdx
+++ b/packages/example/src/pages/components/PageDescription.mdx
@@ -22,7 +22,7 @@ Lorem ipsum dolor sit amet, **consectetur adipiscing elit**, sed do eiusmod temp
 
 ## Code
 
-```markup https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/PageDescription
+```markup src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/PageDescription
 <PageDescription>
 
 Lorem ipsum dolor sit amet, **consectetur adipiscing elit**, sed do eiusmod tempor _incididunt_ ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/example/src/pages/components/PageDescription.mdx
+++ b/packages/example/src/pages/components/PageDescription.mdx
@@ -22,7 +22,7 @@ Lorem ipsum dolor sit amet, **consectetur adipiscing elit**, sed do eiusmod temp
 
 ## Code
 
-```markup src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/PageDescription
+```markup path=components/PageDescription/PageDescription.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/PageDescription
 <PageDescription>
 
 Lorem ipsum dolor sit amet, **consectetur adipiscing elit**, sed do eiusmod tempor _incididunt_ ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -68,7 +68,7 @@ The `<ResourceCard>` component should generally be used inside of a `<Row>` and 
 
 #### With title
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
+```jsx path=components/ResourceCard/ResourceCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="With subtitle"
@@ -84,7 +84,7 @@ The `<ResourceCard>` component should generally be used inside of a `<Row>` and 
 
 #### Only subtitle
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
+```jsx path=components/ResourceCard/ResourceCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="Only subtitle"
@@ -99,7 +99,7 @@ The `<ResourceCard>` component should generally be used inside of a `<Row>` and 
 
 #### Dark
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
+```jsx path=components/ResourceCard/ResourceCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="Alternate color"
@@ -116,7 +116,7 @@ The `<ResourceCard>` component should generally be used inside of a `<Row>` and 
 
 #### Disabled
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
+```jsx path=components/ResourceCard/ResourceCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     title="Disabled card"

--- a/packages/example/src/pages/components/Tabs.mdx
+++ b/packages/example/src/pages/components/Tabs.mdx
@@ -53,7 +53,7 @@ Column two
 
 #### Text
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Tabs
+```jsx path=components/Tabs/Tabs.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Tabs
 // Start with the wrapper component (Tabs)
 <Tabs>
 

--- a/packages/example/src/pages/components/Tabs.mdx
+++ b/packages/example/src/pages/components/Tabs.mdx
@@ -66,19 +66,16 @@ The tab component can be used for a variety of content. From text, to images, to
 
 #### Single image
 
-```
+```jsx path=components/Tabs/Tabs.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Tabs
 <Tab label="Single image">
-
-If your content is full width, you don't need `Row` and `Column`
-
-![color array](images/colors.png)
-
+  If your content is full width, you don't need `Row` and `Column` ![color
+  array](images/colors.png)
 </Tab>
 ```
 
 #### Multiple images
 
-```
+```jsx path=components/Tabs/Tabs.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Tabs
 <Tab label="Two images">
 
 <Row>

--- a/packages/example/src/pages/components/Video.mdx
+++ b/packages/example/src/pages/components/Video.mdx
@@ -24,13 +24,13 @@ The `<Video>` component can render a Vimeo player or a html video player.
 
 #### Vimeo
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Video
+```jsx path=components/Video/Video.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Video
 <Video title="Eyes" vimeoId="310583077" />
 ```
 
 #### Video
 
-```jsx https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Video
+```jsx path=components/Video/Video.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/Video
 <Video src="/videos/hero-video.mp4" poster="/images/poster.png">
   <track default src="/videos/vtt/hero-video.vtt" srcLang="en" />
 </Video>

--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -51,7 +51,7 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 ## H2
 
 ### H3
@@ -74,7 +74,7 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 1. First ordered list item
 1. Item with a nested item
    1. Nested list item
@@ -99,7 +99,7 @@ example.com (but not on Github, for example).
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 [I'm a markdown link](https://www.carbondesignsystem.com)
 
 [I'm a markdown link with title](https://www.carbondesignsystem.com "Google's Homepage")
@@ -119,7 +119,7 @@ Some text to show that the reference links can follow later.
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 ![Alt text goes here](images/quantum.png)
 ```
 
@@ -139,7 +139,7 @@ You can also supply a source code URL or title to go at the top of the code bloc
 
 #### Code
 
-````markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+````markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 Inline `code` has `back-ticks around` it.
 
 ```markdown Title
@@ -170,7 +170,7 @@ raw Markdown line up prettily. You can also use inline Markdown.
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 Colons can be used to align columns.
 
 | Tables        |      Are      |   Cool |
@@ -196,15 +196,15 @@ It is more important than ever that we own our own ethos, make palpable our bran
 > This is a Blockquote.
 > This line is part of the same quote.
 
-> <cite>– Allison</cite>
+> <cite>– Alison</cite>
 
 It is more important than ever that we own our own ethos, make palpable our brand values, and incorporate an instantly identifiable IBMness in everything we do.
 
 #### Code
 
-```markdown https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
+```markdown path=components/markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 > This is a Blockquote.
 > This line is part of the same quote.
 
-> <cite>– Allison</cite>
+> <cite>– Alison</cite>
 ```


### PR DESCRIPTION
Closes #260 

Edited the code snippets by adding the src for the link and a path for where to go to shadow the component. 

I think I got them all but it might be good to check that I didn't miss any code blocks! 

So neat and pretty now! 🎉 

<img width="811" alt="Screen Shot 2019-07-18 at 2 28 22 PM" src="https://user-images.githubusercontent.com/17281178/61486146-65bba500-a968-11e9-9043-d8f5c4810859.png">