### PR TITLE
docs: remove experimental refs

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -17,8 +17,6 @@ module.exports = {
         display: 'browser',
       },
     },
-  ],
-  __experimentalThemes: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -29,11 +29,7 @@ module.exports = {
     description: 'A Gatsby theme for the carbon design system',
     keywords: 'gatsby,theme,carbon',
   },
-  __experimentalThemes: [
-    {
-      resolve: 'gatsby-theme-carbon',
-    },
-  ],
+  plugins: ['gatsby-theme-carbon'],
 };
 ```
 
@@ -46,6 +42,7 @@ siteMetadata: {
     title: 'Gatsby Theme Carbon',
   },
   plugins: [
+    'gatsby-theme-carbon',
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
@@ -58,7 +55,6 @@ siteMetadata: {
       },
     },
   ],
-  __experimentalThemes: [
 ```
 
 ## Favicon
@@ -72,7 +68,7 @@ If you need to override the default favicon, you can do so by passing a relative
 - of one of the follow formats: JPEG, PNG, WebP, TIFF, GIF or SVG.
 
 ```js
-__experimentalThemes: [
+plugins: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {
@@ -87,7 +83,7 @@ __experimentalThemes: [
 If needed, you can add support for additional Plex font weights. Don't forget to specify italics for the additional weights if needed.
 
 ```js
-__experimentalThemes: [
+plugins: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {
@@ -107,7 +103,7 @@ module.exports = {
   siteMetadata: {
     title: 'Gatsby Theme Carbon',
   },
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {
@@ -127,7 +123,7 @@ The GlobalSearch component is disabled by default. If you'd like to implement se
 1. set the isSearchEnabled theme option to true
 
 ```js
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {
@@ -155,7 +151,7 @@ The example `useSearch` hook demonstrates implementing search with [Algolia](htt
 To add a link to the bottom of each page that points to the current page source in GitHub, provide an `repository` object to `siteMetadata` in your `gatsby-config.js` file. You can provide a `baseUrl`, and if needed, the `subDirectory` where your site source lives.
 
 ```js
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: 'gatsby-theme-carbon',
       options: {


### PR DESCRIPTION
This updates the documentation to use the official plugin approach