### PR TITLE
fix: remove janky :active class from tabs component

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.module.scss
@@ -75,10 +75,6 @@ div.tab-container .tab a {
   border-bottom: none !important;
 }
 
-div.tab-container .tab a:active {
-  padding-top: $spacing-05;
-  padding-left: 0;
-}
 
 // Dropdown container
 div.tab-container div {


### PR DESCRIPTION
Hi,
I looked around in the example tabs page (https://gatsby-theme-carbon.now.sh/components/Tabs/) and noticed that when the mouse is pressed (:active), the tab label acts weird IMO.

![ScreenRecording2019-07-29at9](https://user-images.githubusercontent.com/5864772/62025721-b4c3ce80-b1e1-11e9-9432-dd92aae16358.gif)

IMO this janky behavior is a bug, and by looking at the carbon design system's storybook(http://react.carbondesignsystem.com/?path=/story/tabs--default) it seems that it is not intended.

If you think this is the intended behavior, feel free to ignore and close this PR :) 
great job on the theme!! it looks and feels awesome! 