### PR TITLE
Next prev accordion

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
+++ b/packages/gatsby-theme-carbon/src/components/Accordion/Accordion.js
@@ -6,7 +6,7 @@ import { Row, Column } from '../Grid';
 
 const Accordion = ({ className, ...rest }) => (
   <Row>
-    <Column colLg={8}>
+    <Column noGutterSm colLg={8}>
       <CarbonAccordion {...rest} className={cx(className, accordion)} />
     </Column>
   </Row>

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
@@ -30,11 +30,8 @@
   color: $inverse-01;
   @include carbon--type-style('code-02');
   width: calc(100% + 2rem);
-  @include carbon--breakpoint('md') {
-    width: calc(75% - 1rem);
-  }
   @include carbon--breakpoint('lg') {
-    width: calc(66.667% - 1rem);
+    width: calc(67% + 1rem);
   }
 }
 

--- a/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.module.scss
@@ -1,5 +1,5 @@
 .wrapper {
-  background: $ui-05;
+  background: $carbon--gray-90;
   color: $text-04;
 }
 


### PR DESCRIPTION
closes #286 
closes #287
- removes gutter for accordion
- adjusts code snippet to align with 8 col row components
- uses `carbon--gray-90` for next-prev. There is no theme token to represent this value with the white theme.