### PR TITLE
feat: pass MDX frontmatter title into page `<title>`

### DIFF
--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -1,5 +1,7 @@
 ---
 title: Markdown
+description: 'Carbon Gatsby theme markdown documentation'
+keywords: 'ibm,carbon,gatsby,mdx,markdown'
 ---
 
 <PageDescription>
@@ -20,6 +22,18 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
   <AnchorLink>Tables</AnchorLink>
   <AnchorLink>Blockquotes</AnchorLink>
 </AnchorLinks>
+
+## MDX Frontmatter
+
+`gatsby-plugin-mdx` allows you to declare frontmatter in your `.mdx` files with triple dashes at the start and end of the data. The frontmatter can contain any additional data on the specific pages it is defined in, and it can be accessed in the GraphQL data layer. This data can include information like page title, SEO metadata, path, and more.
+
+```md
+---
+title: Markdown
+description: 'Carbon Gatsby theme markdown documentation'
+keywords: 'ibm,carbon,gatsby,mdx,markdown'
+---
+```
 
 ## Text decoration
 

--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -25,7 +25,7 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
 
 ## MDX Frontmatter
 
-`gatsby-plugin-mdx` allows you to declare frontmatter in your `.mdx` files with triple dashes at the start and end of the data. The frontmatter can contain any additional data on the specific pages it is defined in, and it can be accessed in the GraphQL data layer. This data can include information like page title, SEO metadata, path, and more.
+You can declare frontmatter in your `.mdx` files to provide specific metadata for the theme to use. The most important of which is the `title`. You can also provide a descriptions and keywords which will be added to the `head` of your document.
 
 ```md
 ---

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -148,6 +148,7 @@ To add a link to the bottom of each page that points to the current page source 
 
 - `additionalFontWeights` – add support for additional Plex font weights. Don't forget to specify italics for the additional weights if needed.
 - `mdxExtensions` – change the file extensions processed by `gatsby-mdx` (default ['.mdx', '.md'])
+- `titleType` – the format of the title in your head. `site` for your site title, `page` for your individual page title, or `append` for "title – pageTitle" (default 'page')
 
 ```js
 plugins: [
@@ -155,7 +156,8 @@ plugins: [
       resolve: 'gatsby-theme-carbon',
       options: {
         additionalFontWeights: ['200', '200i'],
-        mdxExtensions: ['.mdx']
+        mdxExtensions: ['.mdx'],
+        titleType: 'append'
       },
     },
   ],

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -16,6 +16,7 @@ Gatsby themes allow you to override configuration from the theme by defining the
   <AnchorLink>Image Compression</AnchorLink>
   <AnchorLink>Global Search</AnchorLink>
   <AnchorLink>Edit on Github link</AnchorLink>
+  <AnchorLink>Other options</AnchorLink>
 </AnchorLinks>
 
 ## Site Title and Description
@@ -148,7 +149,11 @@ To add a link to the bottom of each page that points to the current page source 
 
 - `additionalFontWeights` – add support for additional Plex font weights. Don't forget to specify italics for the additional weights if needed.
 - `mdxExtensions` – change the file extensions processed by `gatsby-mdx` (default ['.mdx', '.md'])
-- `titleType` – the format of the title in your head. `site` for your site title, `page` for your individual page title, or `append` for "title – pageTitle" (default 'page')
+- `titleType` – pick between three formats for the `<title>` element for your site. Here are the three options using this page as an example:
+
+  - `page`: "Configuration" (default)
+  - `site`: "Gatsby Theme Carbon"
+  - `append`: "Gatsby Theme Carbon – Configuration"
 
 ```js
 plugins: [

--- a/packages/example/src/pages/index.mdx
+++ b/packages/example/src/pages/index.mdx
@@ -1,5 +1,4 @@
 import HomepageTemplate from 'gatsby-theme-carbon/src/templates/Homepage';
-
 export default HomepageTemplate;
 
 ## MDX content starts here

--- a/packages/gatsby-theme-carbon/gatsby-node.js
+++ b/packages/gatsby-theme-carbon/gatsby-node.js
@@ -21,7 +21,8 @@ exports.onPreBootstrap = ({ store, reporter }) => {
 // We need to provide the actual file that created a specific page to append links for EditLink.
 // We can't do page queries from MDX templates, so we'll add the page's relative path to context after it's created.
 // The context object **is** supplied to MDX templates through the pageContext prop.
-exports.onCreatePage = ({ page, actions }) => {
+exports.onCreatePage = ({ page, actions }, pluginOptions) => {
+  const { titleType = 'page' } = pluginOptions;
   const { createPage, deletePage } = actions;
   const [relativePagePath] = page.componentPath.split('src/pages').splice('-1');
   deletePage(page);
@@ -30,6 +31,7 @@ exports.onCreatePage = ({ page, actions }) => {
     context: {
       ...page.context,
       relativePagePath,
+      titleType,
     },
   });
 };

--- a/packages/gatsby-theme-carbon/src/components/Layout.js
+++ b/packages/gatsby-theme-carbon/src/components/Layout.js
@@ -10,7 +10,13 @@ import Container from './Container';
 
 import '../styles/index.scss';
 
-const Layout = ({ children, homepage, shouldHideHeader, ...rest }) => {
+const Layout = ({
+  children,
+  homepage,
+  shouldHideHeader,
+  pageTitle,
+  ...rest
+}) => {
   const is404 = children.key === null;
 
   useLayoutEffect(() => {
@@ -27,7 +33,7 @@ const Layout = ({ children, homepage, shouldHideHeader, ...rest }) => {
 
   return (
     <>
-      <Meta />
+      <Meta title={pageTitle} />
       <Header shouldHideHeader={shouldHideHeader} />
       <Switcher />
       <LeftNav

--- a/packages/gatsby-theme-carbon/src/components/Layout.js
+++ b/packages/gatsby-theme-carbon/src/components/Layout.js
@@ -15,6 +15,8 @@ const Layout = ({
   homepage,
   shouldHideHeader,
   pageTitle,
+  pageDescription,
+  pageKeywords,
   ...rest
 }) => {
   const is404 = children.key === null;
@@ -33,7 +35,11 @@ const Layout = ({
 
   return (
     <>
-      <Meta title={pageTitle} />
+      <Meta
+        pageTitle={pageTitle}
+        pageDescription={pageDescription}
+        pageKeywords={pageKeywords}
+      />
       <Header shouldHideHeader={shouldHideHeader} />
       <Switcher />
       <LeftNav

--- a/packages/gatsby-theme-carbon/src/components/Layout.js
+++ b/packages/gatsby-theme-carbon/src/components/Layout.js
@@ -14,6 +14,7 @@ const Layout = ({
   children,
   homepage,
   shouldHideHeader,
+  titleType,
   pageTitle,
   pageDescription,
   pageKeywords,
@@ -36,6 +37,7 @@ const Layout = ({
   return (
     <>
       <Meta
+        titleType={titleType}
         pageTitle={pageTitle}
         pageDescription={pageDescription}
         pageKeywords={pageKeywords}

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useMetadata } from '../util/hooks';
 
-const Meta = ({ title: pageTitle }) => {
+const Meta = ({ pageTitle, pageDescription, pageKeywords }) => {
   const { title, description, keywords } = useMetadata();
   return (
     <Helmet
@@ -10,11 +10,11 @@ const Meta = ({ title: pageTitle }) => {
       meta={[
         {
           name: 'description',
-          content: description,
+          content: pageDescription || description,
         },
         {
           name: 'keywords',
-          content: keywords,
+          content: pageKeywords || keywords,
         },
       ]}
     />

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -2,11 +2,26 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useMetadata } from '../util/hooks';
 
-const Meta = ({ pageTitle, pageDescription, pageKeywords }) => {
+const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
   const { title, description, keywords } = useMetadata();
+
+  const getPageTitle = () => {
+    switch (titleType) {
+      case 'page':
+        // use site title for fallback
+        return pageTitle || title;
+      case 'site':
+        return title;
+      case 'append':
+        return `${title}${pageTitle ? ` – ${pageTitle}` : ''}`;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Helmet
-      title={pageTitle ? `${title} - ${pageTitle}` : title}
+      title={getPageTitle()}
       meta={[
         {
           name: 'description',

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useMetadata } from '../util/hooks';
 
-const Meta = () => {
+const Meta = ({ title: pageTitle }) => {
   const { title, description, keywords } = useMetadata();
   return (
     <Helmet
-      title={title}
+      title={pageTitle ? `${title} - ${pageTitle}` : title}
       meta={[
         {
           name: 'description',

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -14,7 +14,7 @@ import Main from '../components/Main';
 
 const Default = ({ pageContext, children, location }) => {
   const { frontmatter = {}, relativePagePath } = pageContext;
-  const { tabs, title } = frontmatter;
+  const { tabs, title, description, keywords } = frontmatter;
   const scrollDirection = useScrollDirection();
   const shouldHideHeader = !!tabs && scrollDirection === 'down';
 
@@ -45,6 +45,8 @@ const Default = ({ pageContext, children, location }) => {
       shouldHideHeader={shouldHideHeader}
       homepage={false}
       pageTitle={title}
+      pageDescription={description}
+      pageKeywords={keywords}
     >
       <PageHeader
         shouldHideHeader={shouldHideHeader}

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -41,7 +41,11 @@ const Default = ({ pageContext, children, location }) => {
 
   const currentTab = getCurrentTab();
   return (
-    <Layout shouldHideHeader={shouldHideHeader} homepage={false}>
+    <Layout
+      shouldHideHeader={shouldHideHeader}
+      homepage={false}
+      pageTitle={title}
+    >
       <PageHeader
         shouldHideHeader={shouldHideHeader}
         title={title}

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -13,7 +13,7 @@ import PageTabs from '../components/PageTabs';
 import Main from '../components/Main';
 
 const Default = ({ pageContext, children, location }) => {
-  const { frontmatter = {}, relativePagePath } = pageContext;
+  const { frontmatter = {}, relativePagePath, titleType } = pageContext;
   const { tabs, title, description, keywords } = frontmatter;
   const scrollDirection = useScrollDirection();
   const shouldHideHeader = !!tabs && scrollDirection === 'down';
@@ -47,6 +47,7 @@ const Default = ({ pageContext, children, location }) => {
       pageTitle={title}
       pageDescription={description}
       pageKeywords={keywords}
+      titleType={titleType}
     >
       <PageHeader
         shouldHideHeader={shouldHideHeader}

--- a/packages/gatsby-theme-carbon/src/templates/Homepage.js
+++ b/packages/gatsby-theme-carbon/src/templates/Homepage.js
@@ -14,17 +14,26 @@ const Homepage = ({
   SecondCallout,
   location,
   pageContext,
-}) => (
-  <Layout homepage>
-    {Banner}
-    {FirstCallout}
-    <Main>{children}</Main>
-    {SecondCallout}
-    <NextPrevious location={location} pageContext={pageContext} />
-    <WebsiteBackToTopBtn />
-  </Layout>
-);
-
+}) => {
+  const { frontmatter = {}, titleType } = pageContext;
+  const { title, description, keywords } = frontmatter;
+  return (
+    <Layout
+      pageTitle={title}
+      pageDescription={description}
+      pageKeywords={keywords}
+      titleType={titleType}
+      homepage
+    >
+      {Banner}
+      {FirstCallout}
+      <Main>{children}</Main>
+      {SecondCallout}
+      <NextPrevious location={location} pageContext={pageContext} />
+      <WebsiteBackToTopBtn />
+    </Layout>
+  );
+};
 Homepage.defaultProps = {
   Banner: (
     <HomepageBanner

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,9 +2278,9 @@
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
 
 "@types/node@*":
-  version "12.6.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
-  integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
+  version "12.6.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.9.tgz#ffeee23afdc19ab16e979338e7b536fdebbbaeaf"
+  integrity sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==
 
 "@types/node@^7.0.11":
   version "7.10.7"
@@ -3894,7 +3894,7 @@ camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-camelcase-css@2.0.1:
+camelcase-css@2.0.1, camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
@@ -5575,7 +5575,15 @@ dom-helpers@^3.2.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
+dom-serializer@0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
+  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
+dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
@@ -5597,6 +5605,11 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -5721,9 +5734,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
-  version "1.3.208"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.208.tgz#6df90b89e8b9af139db3c8d7a6b935db0801e61c"
-  integrity sha512-ljgZXaKSfRg32jEl1V8zRJaT3u653jxfZRztKQWM/I1kE+ifBCQKRY+jOPzb4JS48a4czvT/LQfjdiDq5qjU4g==
+  version "1.3.210"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz#0ce6247366c5771d4f5663a5879388fd1adefb7e"
+  integrity sha512-m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5844,6 +5857,11 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
 env-paths@^1.0.0:
   version "1.0.0"
@@ -7030,10 +7048,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gatsby-cli@^2.7.21:
-  version "2.7.21"
-  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.7.21.tgz#c406a39013cd3ddce05e6be2504fbf380e6bff1f"
-  integrity sha512-M80MfpIm/S6IMGDthPu5kEUT4i6SXYjmfpg/0/BJxPpvj5xA+CMECzmLk1olSw+5//nVXpf2r3nuiZl1AR78jA==
+gatsby-cli@^2.7.21, gatsby-cli@^2.7.26:
+  version "2.7.26"
+  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.7.26.tgz#e1194d92aa57ee739c1818fce63d502dde6dff09"
+  integrity sha512-QqCppRfFTeJM1ce4lf/WEZHXdcKAATq1WqgwjLpDfUzeZI9XZSzSh74v1+wGZh8TA+J5hzkieTdQV7eP5YRjYQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/runtime" "^7.0.0"
@@ -7051,7 +7069,7 @@ gatsby-cli@^2.7.21:
     execa "^0.8.0"
     fs-exists-cached "^1.0.0"
     fs-extra "^4.0.1"
-    gatsby-telemetry "^1.1.7"
+    gatsby-telemetry "^1.1.11"
     hosted-git-info "^2.6.0"
     is-valid-path "^0.1.1"
     lodash "^4.17.14"
@@ -7145,7 +7163,48 @@ gatsby-plugin-manifest@^2.1.1:
     semver "^5.6.0"
     sharp "^0.22.1"
 
-gatsby-plugin-mdx@^1.0.11, gatsby-plugin-mdx@^1.0.13:
+gatsby-plugin-mdx@^1.0.11:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.22.tgz#b5c429540a8c41b582d55ad9604b85a38be77203"
+  integrity sha512-+ZBuy7I0a4T+udlPnoUgII6PIm3YKHv26hNBXhZYTPk//R4LiCD3vlhZeeHqHAQaOamNquHt7DPxXZezNIATkw==
+  dependencies:
+    "@babel/core" "^7.4.3"
+    "@babel/generator" "^7.5.5"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.4.3"
+    "@babel/preset-env" "^7.4.3"
+    "@babel/preset-react" "^7.0.0"
+    "@babel/types" "^7.5.5"
+    camelcase-css "^2.0.1"
+    change-case "^3.1.0"
+    core-js "2"
+    dataloader "^1.4.0"
+    debug "^4.0.1"
+    escape-string-regexp "^1.0.5"
+    eval "^0.1.4"
+    fs-extra "^7.0.0"
+    gray-matter "^4.0.1"
+    json5 "^2.1.0"
+    loader-utils "^1.2.3"
+    lodash "^4.17.14"
+    mdast-util-to-string "^1.0.4"
+    mdast-util-toc "^3.0.0"
+    mime "^2.3.1"
+    p-queue "^5.0.0"
+    pretty-bytes "^5.1.0"
+    remark "^10.0.0"
+    remark-retext "^3.1.2"
+    retext-english "^3.0.2"
+    slash "^2.0.0"
+    static-site-generator-webpack-plugin "^3.4.2"
+    style-to-object "^0.2.3"
+    underscore.string "^3.3.4"
+    unified "^8.3.2"
+    unist-util-map "^1.0.4"
+    unist-util-remove "^1.0.1"
+    unist-util-visit "^1.4.0"
+
+gatsby-plugin-mdx@^1.0.13:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.19.tgz#e259daed7b35736ba68f3440eabe9d64257a3c14"
   integrity sha512-9kB2Sdr4f3x7Iao3g+qWuAdXavqlJ6qq1hDLIkceXHntB9w4MFwkGfDBMXzZwxEVVz2qIbrfo4JDh9Imcr6tZA==
@@ -7229,9 +7288,9 @@ gatsby-plugin-sass-resources@^2.0.0:
     webpack "^4.0.0"
 
 gatsby-plugin-sass@^2.0.11:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-2.1.3.tgz#e829e416916b7a288eb435324bb0308da91e03ef"
-  integrity sha512-R2SwOeFc2iz6NdHcYdfvcdwQIrQPzErZxZt/nACLkOPVrdulcakbGN+x6coUwovkZLHueXLpMFlhwi+eezNVTw==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-2.1.4.tgz#93602fe2ccff6a1b86b392e36becfc783e92feb8"
+  integrity sha512-aVd5rBKUNn4AzvxbRZKMKAo0x5y532Adj5wUWGbd0wW0yyAuGa0nc/wd58Wf7kVChTI1uAaOMnbGh+mW6owmjw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     sass-loader "^7.0.1"
@@ -7333,7 +7392,28 @@ gatsby-remark-unwrap-images@^1.0.1:
     unist-util-remove "^1.0.1"
     unist-util-visit "^1.4.0"
 
-gatsby-source-filesystem@^2.0.37, gatsby-source-filesystem@^2.1.3:
+gatsby-source-filesystem@^2.0.37:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.8.tgz#a31cb5992c60c0a16fe32ff087f35eeff7848962"
+  integrity sha512-/EhMIlp6LA09+zzNkkhSW/zmJON9Ma9HQ5NpGTop7RVf9RIWiqhLA3klqVAnOwcYo2ALvAenGdGX2pgfH4PiMw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    better-queue "^3.8.7"
+    bluebird "^3.5.0"
+    chokidar "2.1.2"
+    file-type "^10.2.0"
+    fs-extra "^5.0.0"
+    gatsby-core-utils "^1.0.0"
+    got "^7.1.0"
+    md5-file "^3.1.1"
+    mime "^2.2.0"
+    pretty-bytes "^4.0.2"
+    progress "^2.0.3"
+    read-chunk "^3.0.0"
+    valid-url "^1.0.9"
+    xstate "^3.1.0"
+
+gatsby-source-filesystem@^2.1.3:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.7.tgz#ad46eec78831e69dd716cb8188e2ed7df68b9981"
   integrity sha512-CieDkGzqjwbRJymXVoz9MIoV8li2NU7W5VWwWRWcztq1mV83PgkN7B6qkljDEuosCeFtMZbfQZKij5YugyBbkg==
@@ -7354,10 +7434,10 @@ gatsby-source-filesystem@^2.0.37, gatsby-source-filesystem@^2.1.3:
     valid-url "^1.0.9"
     xstate "^3.1.0"
 
-gatsby-telemetry@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.1.7.tgz#dd2a363852ce87990249586e75189e7b05d1f561"
-  integrity sha512-mVJwkg4kdHGBt1OKlpcDO1gKoRd5oiJHKYR1jGrShXbB8FE4c52Z2Geg0xMKNXCeUbMUEZB78IPGlJ94nnPAag==
+gatsby-telemetry@^1.1.11, gatsby-telemetry@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.1.11.tgz#7c98881759fa8f61a6bf4f2ee2fb9ac74c6eb592"
+  integrity sha512-pEsDQCHSID0HWj9gzDjkA0Y07j9ItpQ9vYdHsyYeNvwan+L6dI6r2AfSM/gfGL0FHyj14JGixxNChAG1N36Utw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/runtime" "^7.0.0"
@@ -7416,7 +7496,7 @@ gatsby-transformer-yaml@^2.1.12:
     lodash "^4.17.14"
     unist-util-select "^1.5.0"
 
-gatsby@^2.13.24, gatsby@^2.4.2:
+gatsby@^2.13.24:
   version "2.13.45"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.13.45.tgz#b1215bacab56cfcfc1c84cd1ef8aa731bdc06265"
   integrity sha512-LvbEjb5gpYjTwpjGv6u70TC1ryyjzLuU+YY//bcIdI4UxioX2GKD2caQYQ8de5clMS7Vhqd7I4D0jq8hwmDxfQ==
@@ -7484,6 +7564,138 @@ gatsby@^2.13.24, gatsby@^2.4.2:
     gatsby-plugin-page-creator "^2.1.5"
     gatsby-react-router-scroll "^2.1.3"
     gatsby-telemetry "^1.1.7"
+    glob "^7.1.1"
+    got "8.0.0"
+    graphql "^14.1.1"
+    graphql-compose "^6.3.2"
+    graphql-playground-middleware-express "^1.7.10"
+    invariant "^2.2.4"
+    is-relative "^1.0.0"
+    is-relative-url "^2.0.0"
+    is-wsl "^1.1.0"
+    jest-worker "^23.2.0"
+    json-loader "^0.5.7"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.14"
+    lokijs "^1.5.7"
+    md5 "^2.2.1"
+    md5-file "^3.1.1"
+    micromatch "^3.1.10"
+    mime "^2.2.0"
+    mini-css-extract-plugin "^0.4.0"
+    mitt "^1.1.2"
+    mkdirp "^0.5.1"
+    moment "^2.21.0"
+    name-all-modules-plugin "^1.0.1"
+    normalize-path "^2.1.1"
+    null-loader "^0.1.1"
+    opentracing "^0.14.3"
+    optimize-css-assets-webpack-plugin "^5.0.1"
+    parseurl "^1.3.2"
+    physical-cpu-count "^2.0.0"
+    pnp-webpack-plugin "^1.4.1"
+    postcss-flexbugs-fixes "^3.0.0"
+    postcss-loader "^2.1.3"
+    prop-types "^15.6.1"
+    raw-loader "^0.5.1"
+    react-dev-utils "^4.2.3"
+    react-error-overlay "^3.0.0"
+    react-hot-loader "^4.12.5"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    semver "^5.6.0"
+    shallow-compare "^1.2.2"
+    sift "^5.1.0"
+    signal-exit "^3.0.2"
+    slash "^1.0.0"
+    socket.io "^2.0.3"
+    stack-trace "^0.0.10"
+    string-similarity "^1.2.0"
+    style-loader "^0.21.0"
+    terser-webpack-plugin "1.2.4"
+    "true-case-path" "^1.0.3"
+    type-of "^2.0.1"
+    url-loader "^1.0.1"
+    util.promisify "^1.0.0"
+    uuid "^3.1.0"
+    v8-compile-cache "^1.1.0"
+    webpack "~4.28.4"
+    webpack-dev-middleware "^3.0.1"
+    webpack-dev-server "^3.1.14"
+    webpack-hot-middleware "^2.21.0"
+    webpack-merge "^4.1.0"
+    webpack-stats-plugin "^0.1.5"
+    xstate "^4.3.2"
+    yaml-loader "^0.5.0"
+
+gatsby@^2.4.2:
+  version "2.13.50"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.13.50.tgz#6556a6739fa4d9662d69e72e30a5bea180945158"
+  integrity sha512-30e9L6QcsOiQ04/gjH74IM6rsOEgXJGcKCNDEXTxTqiUpVIELZHy3+8lJLhDlGNxunL4GYI9vqq7k8NleKTAlA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/core" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@gatsbyjs/relay-compiler" "2.0.0-printer-fix.2"
+    "@hapi/joi" "^15.0.0"
+    "@mikaelkristiansson/domready" "^1.0.9"
+    "@pieh/friendly-errors-webpack-plugin" "1.7.0-chalk-2"
+    "@reach/router" "^1.1.1"
+    address "1.0.3"
+    autoprefixer "^9.6.0"
+    babel-core "7.0.0-bridge.0"
+    babel-eslint "^9.0.0"
+    babel-loader "^8.0.0"
+    babel-plugin-add-module-exports "^0.2.1"
+    babel-plugin-dynamic-import-node "^1.2.0"
+    babel-plugin-remove-graphql-queries "^2.7.2"
+    babel-preset-gatsby "^0.2.8"
+    better-opn "0.1.4"
+    better-queue "^3.8.6"
+    bluebird "^3.5.0"
+    browserslist "3.2.8"
+    cache-manager "^2.9.0"
+    cache-manager-fs-hash "^0.0.6"
+    chalk "^2.3.2"
+    chokidar "2.1.2"
+    common-tags "^1.4.0"
+    compression "^1.7.3"
+    convert-hrtime "^2.0.0"
+    copyfiles "^1.2.0"
+    core-js "^2.5.0"
+    cors "^2.8.5"
+    css-loader "^1.0.0"
+    debug "^3.1.0"
+    del "^3.0.0"
+    detect-port "^1.2.1"
+    devcert-san "^0.3.3"
+    dotenv "^4.0.0"
+    eslint "^5.6.0"
+    eslint-config-react-app "^3.0.0"
+    eslint-loader "^2.1.0"
+    eslint-plugin-flowtype "^2.46.1"
+    eslint-plugin-graphql "^3.0.3"
+    eslint-plugin-import "^2.9.0"
+    eslint-plugin-jsx-a11y "^6.0.3"
+    eslint-plugin-react "^7.8.2"
+    event-source-polyfill "^1.0.5"
+    express "^4.16.3"
+    express-graphql "^0.7.1"
+    fast-levenshtein "^2.0.6"
+    file-loader "^1.1.11"
+    flat "^4.0.0"
+    fs-exists-cached "1.0.0"
+    fs-extra "^5.0.0"
+    gatsby-cli "^2.7.26"
+    gatsby-core-utils "^1.0.3"
+    gatsby-graphiql-explorer "^0.2.3"
+    gatsby-link "^2.2.4"
+    gatsby-plugin-page-creator "^2.1.5"
+    gatsby-react-router-scroll "^2.1.3"
+    gatsby-telemetry "^1.1.11"
     glob "^7.1.1"
     got "8.0.0"
     graphql "^14.1.1"
@@ -13687,9 +13899,9 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -14909,7 +15121,7 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-style-to-object@0.2.3, style-to-object@^0.2.1:
+style-to-object@0.2.3, style-to-object@^0.2.1, style-to-object@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.2.3.tgz#afcf42bc03846b1e311880c55632a26ad2780bcb"
   integrity sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==


### PR DESCRIPTION
this PR passes the MDX frontmatter title into the `<Meta>` component HTML title element. not sure how configurable we want this to be, but this is an option for getting dynamic page titles in the format we're looking for in the IDL site