### PR TITLE
fix: extra space below images in dodont

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
@@ -20,6 +20,7 @@
 }
 
 .#{$prefix}--example__content img {
+  display: block;
   margin-bottom: 0;
   width: 100%;
 }


### PR DESCRIPTION
Fixes extra space appearing below images inside the do-dont example. 

related to https://github.com/carbon-design-system/design-language-website/pull/119