### PR TITLE
fix: homepage style bugs

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Container/Container.js
+++ b/packages/gatsby-theme-carbon/src/components/Container/Container.js
@@ -42,7 +42,9 @@ const Container = ({ children, homepage }) => {
       />
       <div
         aria-hidden={overlayVisible}
-        className={`${homepage ? 'container--homepage' : 'container'}`}
+        className={`${
+          homepage ? 'container--homepage container' : 'container'
+        }`}
       >
         {children}
       </div>

--- a/packages/gatsby-theme-carbon/src/components/Homepage/Callout.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Homepage/Callout.module.scss
@@ -17,3 +17,11 @@
 .secondColumn {
   @include carbon--type-style('expressive-paragraph-01', true);
 }
+
+.grid a {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
+++ b/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
@@ -5,11 +5,6 @@
 
 .container--homepage a {
   color: $carbon--blue-40;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
 }
 
 // Homepage image header area

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
@@ -12,7 +12,7 @@
 }
 
 .resource-card-group .#{$prefix}--resource-card--dark {
-  border-top-color: 1px solid $carbon--black-100;
+  border-top-color: $carbon--black-100;
 }
 
 .resource-card-group


### PR DESCRIPTION
Noticed a couple of issues while working on the Carbon homepage. Fixes border for card groups on the homepage. and adds the container class to the homepage (we're using this for some styling)

makes link styling specifc to the callout component, otherwise it was affecting cards and anything else on the page