### PR TITLE
fix: don't restrict grid width on the homepage

### DIFF
--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -10,7 +10,6 @@
 
 .container .#{$prefix}--grid {
   margin: 0;
-  max-width: rem(1584px);
 
   @include carbon--breakpoint('lg') {
     padding-left: calc(
@@ -25,6 +24,11 @@
 
 .container .#{$prefix}--col-no-gutter {
   padding: 0;
+}
+
+// Grids on the homepage should be full width
+.container:not(.container--homepage) .#{$prefix}--grid {
+  max-width: rem(1584px);
 }
 
 //---------------------------------------


### PR DESCRIPTION
closes #298

I'd like to deal with the page styles in a more holistic way. I think we could start planning for refactoring them along with the markdown styles.