### PR TITLE
fix(navigation): explicitly match paths to links for selected state

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -20,7 +20,6 @@ module.exports = {
     {
       resolve: 'gatsby-theme-carbon',
       options: {
-        additionalFontWeights: ['200', '200i'],
         repository: {
           baseUrl:
             'https://github.com/carbon-design-system/gatsby-theme-carbon',

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItem.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItem.js
@@ -73,7 +73,7 @@ const SubNavItems = ({ items, pathname, onClick }) =>
     const hasActiveTab =
       item.path.split('/').filter(Boolean).length > 2
         ? pathname.includes(item.path.slice(0, item.path.lastIndexOf('/')))
-        : pathname.includes(item.path);
+        : pathname.split('/').toString() === item.path.split('/').toString();
     return (
       <SideNavMenuItem
         to={`${item.path}`}


### PR DESCRIPTION
Took a shot at a fix to resolve #265 

Slightly modifies the left nav item to more explicitly check the paths against one another, rather than relying on `includes()`.