### PR TITLE
fix(DoDontExample): changed targeted class so video button is not off center

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
@@ -149,7 +149,7 @@
   margin-bottom: 0;
 }
 
-// Video
-.#{$prefix}--example [class^='Video-module--video'] {
+//Video
+.#{$prefix}--example [class^='Video-module--video-container'] {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Closes #317 

Changed the class being selected from the video styles in `do-dont-example.scss`

**Testing**

Check and see that the video play button is in the center in a DoDontExample

