### PR TITLE
fix(blockquote): list text color

### DIFF
--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -20,7 +20,7 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
   <AnchorLink>Images</AnchorLink>
   <AnchorLink>Code blocks</AnchorLink>
   <AnchorLink>Tables</AnchorLink>
-  <AnchorLink>Blockquotes</AnchorLink>
+  <AnchorLink>Blockquotes and citations</AnchorLink>
 </AnchorLinks>
 
 ## MDX Frontmatter
@@ -205,20 +205,32 @@ raw Markdown line up prettily. You can also use inline Markdown.
 
 ## Blockquotes and citations
 
-It is more important than ever that we own our own ethos, make palpable our brand values, and incorporate an instantly identifiable IBMness in everything we do.
-
 > This is a Blockquote.
 > This line is part of the same quote.
 
-> <cite>– Alison</cite>
+> Blockquotes support basic markdown syntax,
+> like **bold** ~~strikethroughs~~ and [links.](#)
 
-It is more important than ever that we own our own ethos, make palpable our brand values, and incorporate an instantly identifiable IBMness in everything we do.
+> 1. As
+> 1. Well
+> 1. As
+> 1. Lists!
+
+> <cite>– Alison</cite>
 
 #### Code
 
 ```markdown path=components/markdown src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/markdown
 > This is a Blockquote.
 > This line is part of the same quote.
+
+> Blockquotes support basic markdown syntax,
+> like **bold** ~~strikethroughs~~ and [links.](#)
+
+> 1. As
+> 1. Well
+> 1. As
+> 1. Lists!
 
 > <cite>– Alison</cite>
 ```

--- a/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
@@ -29,43 +29,6 @@
 }
 
 //---------------------------------------
-// Blockquote
-//---------------------------------------
-.blockquote {
-  margin: $spacing-08 0 $spacing-08 $spacing-08;
-  color: $carbon--blue-60;
-  font-style: italic;
-}
-
-.blockquote .paragraph {
-  @include carbon--type-style('expressive-heading-03', true);
-  margin-bottom: 0;
-}
-
-.blockquote .paragraph--responsive {
-  // 6 col
-  @include carbon--breakpoint('md') {
-    width: calc(75% - 3rem);
-  }
-
-  // 8 col
-  @include carbon--breakpoint('lg') {
-    width: calc(66.667% - 3rem);
-  }
-}
-
-// If quote is inside a user specified row then allow the grid code to set the width
-:global(.#{$prefix}--row) .blockquote .paragraph {
-  width: calc(100% - 3rem);
-}
-
-.blockquote cite {
-  @include carbon--type-style('body-long-01');
-  display: block;
-  margin-top: $spacing-02;
-}
-
-//---------------------------------------
 // Responsive widths
 //---------------------------------------
 
@@ -117,6 +80,47 @@
   @include carbon--breakpoint('md') {
     margin-right: 1.5rem;
   }
+}
+
+//---------------------------------------
+// Blockquote
+//---------------------------------------
+.blockquote {
+  margin: $spacing-08 0 $spacing-08 $spacing-08;
+  color: $carbon--blue-60;
+  font-style: italic;
+}
+
+.blockquote .paragraph {
+  @include carbon--type-style('expressive-heading-03', true);
+  margin-bottom: 0;
+}
+
+.blockquote .paragraph--responsive {
+  // 6 col
+  @include carbon--breakpoint('md') {
+    width: calc(75% - 3rem);
+  }
+
+  // 8 col
+  @include carbon--breakpoint('lg') {
+    width: calc(66.667% - 3rem);
+  }
+}
+
+// If quote is inside a user specified row then allow the grid code to set the width
+:global(.#{$prefix}--row) .blockquote .paragraph {
+  width: calc(100% - 3rem);
+}
+
+.blockquote cite {
+  @include carbon--type-style('body-long-01');
+  display: block;
+  margin-top: $spacing-02;
+}
+
+.blockquote .list-item {
+  color: $carbon--blue-60;
 }
 
 //---------------------------------------


### PR DESCRIPTION
Source
- Add a css selector for .list-style
  - I had to reorder the blockquote css below list-item's due to stylelint's `no-descending-specificity`

Example
- Fix the anchor link, it wasn't working
- Expand the block quote example

Closes #261 