### PR TITLE
refactor: remove addons-website dependency

### DIFF
--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -19,7 +19,6 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "@carbon/addons-website": "0.0.1-alpha.21",
     "@carbon/elements": "^10.4.0",
     "@carbon/icons-react": "^10.4.1",
     "@emotion/core": "^10.0.10",
@@ -54,6 +53,7 @@
     "node-sass": "^4.11.0",
     "prism-react-renderer": "^0.1.7",
     "prop-types": "^15.7.2",
+    "react-scroll-up": "^1.3.3",
     "react-helmet": "^6.0.0-beta",
     "remark-slug": "^5.1.2",
     "slugify": "^1.3.4",

--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.js
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { UpToTop20 } from '@carbon/icons-react';
+import ScrollToTop from 'react-scroll-up';
+
+import { button } from './BackToTopBtn.module.scss';
+
+const BackToTopBtn = () => (
+  <ScrollToTop showUnder={300} style={{ zIndex: 9999 }}>
+    <button className={button} type="button" aria-label="Back to Top">
+      <UpToTop20 />
+    </button>
+  </ScrollToTop>
+);
+
+export default BackToTopBtn;

--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
@@ -1,0 +1,33 @@
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+
+.button {
+  width: rem(48px);
+  height: rem(48px);
+  border-radius: rem(24px);
+  background: $carbon--gray-30;
+  border-color: transparent;
+  position: fixed;
+  bottom: rem(50px);
+  right: rem(30px);
+  cursor: pointer;
+  z-index: 9999;
+  padding-top: 0.325rem;
+}
+
+.button:hover {
+  background: $carbon--gray-90;
+  border-color: transparent;
+}
+
+.button:focus {
+  outline: none;
+  border: 2px solid $focus;
+}
+
+.button svg {
+  fill: $carbon--black-100;
+}
+
+.button:hover svg {
+  fill: $carbon--white-0;
+}

--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/index.js
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/index.js
@@ -1,0 +1,3 @@
+import BackToTopBtn from './BackToTopBtn';
+
+export default BackToTopBtn;

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -17,6 +17,28 @@ header.header {
   top: -48px;
 }
 
+.header :global(.bx--header__action--menu) {
+  border-width: 2px;
+  display: block;
+
+  @include carbon--breakpoint('lg') {
+    display: none;
+  }
+}
+
+.header :global(.bx--header__name) {
+  @include carbon--type-style('body-short-02');
+  padding-left: $spacing-03;
+
+  @include carbon--breakpoint('lg') {
+    padding-left: $spacing-05;
+  }
+}
+
 .header :global(.bx--header__name):focus {
   box-shadow: none;
+}
+
+.header :global(.bx--header__name) span {
+  font-weight: 600;
 }

--- a/packages/gatsby-theme-carbon/src/styles/internal/_global.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_global.scss
@@ -21,11 +21,8 @@ $feature-flags: (
 @import '~carbon-components/scss/components/tabs/tabs';
 @import '~carbon-components/scss/components/list/list';
 
-@import '~@carbon/addons-website/scss/components/website-grid';
-@import '~@carbon/addons-website/scss/components/website-header';
-@import '~@carbon/addons-website/scss/components/website-header-nav';
-@import '~@carbon/addons-website/scss/components/website-side-nav';
-@import '~@carbon/addons-website/scss/components/website-back-to-top-btn';
+// Shell overrides until themeing is ready
+@import 'website-side-nav';
 
 // Typography
 @include carbon--type-reset();

--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -119,3 +119,52 @@ img[src*='svg'] {
 [hidden] {
   display: none;
 }
+
+// Grid style updates/overrides, moved over from deprecated addons pacakge
+
+// No gutter class names
+.container .#{$prefix}--no-gutter-lg {
+  @include carbon--breakpoint('lg') {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.container .#{$prefix}--no-gutter-md {
+  @include carbon--breakpoint('md') {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.container .#{$prefix}--no-gutter-sm {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.container .#{$prefix}--no-gutter-lg--left {
+  @include carbon--breakpoint('lg') {
+    padding-left: 0;
+  }
+}
+
+.container .#{$prefix}--no-gutter-md--left {
+  @include carbon--breakpoint('md') {
+    padding-left: 0;
+  }
+}
+
+.container .#{$prefix}--no-gutter-sm--left {
+  padding-left: 0;
+}
+
+// Clears styles for nested grid components
+.container .#{$prefix}--row .#{$prefix}--row {
+  margin: 0;
+}
+
+.container .#{$prefix}--row .#{$prefix}--row > div {
+  margin: 0;
+  max-width: 100%;
+  flex: auto;
+}

--- a/packages/gatsby-theme-carbon/src/styles/internal/_website-side-nav.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_website-side-nav.scss
@@ -1,0 +1,293 @@
+// Bottom links
+.#{$prefix}--side-nav__divider {
+  display: block;
+  margin: rem(64px) 1rem 0;
+  border-style: solid;
+  border-bottom: none;
+  border-color: $carbon--gray-80;
+}
+
+.#{$prefix}--side-nav--website--light .#{$prefix}--side-nav__divider {
+  border-color: $ui-03;
+}
+
+.#{$prefix}--side-nav--website .#{$prefix}--side-nav__item {
+  &:nth-last-child(2) {
+    .#{$prefix}--side-nav--website-link {
+      margin-top: $spacing-03;
+    }
+  }
+
+  &:nth-last-child(2),
+  &:nth-last-child(1) {
+    .#{$prefix}--side-nav--website-link {
+      flex-direction: row-reverse;
+      justify-content: space-between;
+    }
+
+    .#{$prefix}--side-nav__link-text {
+      padding-left: 0;
+    }
+
+    .#{$prefix}--side-nav--website-link > .#{$prefix}--side-nav__icon {
+      display: block;
+      flex: 0;
+    }
+  }
+}
+
+//===================
+// SIDE NAV overrides
+//===================
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item.#{$prefix}--side-nav__item--active
+  .#{$prefix}--side-nav__submenu[aria-haspopup='true'] {
+  color: $text-01;
+
+  .#{$prefix}--side-nav__icon svg {
+    fill: $icon-01;
+  }
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item.#{$prefix}--side-nav__item--active
+  .#{$prefix}--side-nav__submenu[aria-haspopup='true'][aria-expanded='false'] {
+  background-color: $ui-03;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    background-color: $brand-01;
+  }
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light {
+  background-color: $ui-02;
+  border-right: none;
+}
+
+.#{$prefix}--side-nav__navigation {
+  padding-top: $spacing-05;
+  background-color: $ui-05;
+}
+
+.#{$prefix}--side-nav--website--light .#{$prefix}--side-nav__navigation {
+  background-color: $ui-02;
+}
+
+.#{$prefix}--side-nav--website .#{$prefix}--side-nav__icon > svg {
+  fill: $active-01;
+}
+
+.#{$prefix}--side-nav--website--light .#{$prefix}--side-nav__icon > svg {
+  fill: $text-02;
+}
+
+.#{$prefix}--side-nav .#{$prefix}--side-nav__submenu[aria-haspopup='true'],
+.#{$prefix}--side-nav__item > a.#{$prefix}--side-nav__link {
+  @include carbon--type-style('heading-01');
+  color: $active-01;
+}
+
+.#{$prefix}--side-nav
+  a.#{$prefix}--side-nav__link
+  > .#{$prefix}--side-nav__link-text {
+  color: $active-01;
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__submenu[aria-haspopup='true'],
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item
+  > a.#{$prefix}--side-nav__link,
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  a.#{$prefix}--side-nav__link
+  > .#{$prefix}--side-nav__link-text {
+  color: $text-02;
+}
+
+.#{$prefix}--side-nav
+  a.#{$prefix}--side-nav__link:hover
+  > .#{$prefix}--side-nav__link-text,
+.#{$prefix}--side-nav
+  a.#{$prefix}--side-nav__link[aria-current='page']
+  > .#{$prefix}--side-nav__link-text {
+  color: $ui-01;
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  a.#{$prefix}--side-nav__link:hover
+  > .#{$prefix}--side-nav__link-text,
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  a.#{$prefix}--side-nav__link[aria-current='page']
+  > .#{$prefix}--side-nav__link-text {
+  color: $text-01;
+}
+
+.#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover {
+  background-color: $ui-05;
+}
+
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover {
+  background-color: $ui-02;
+}
+
+.#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  > .#{$prefix}--side-nav__submenu,
+.#{$prefix}--side-nav__menu[role='menu']
+  a.#{$prefix}--side-nav__link[role='menuitem']:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
+.#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  > .#{$prefix}--side-nav__link {
+  background-color: #353535;
+  color: $ui-01;
+
+  .#{$prefix}--side-nav__link-text {
+    color: $ui-01;
+  }
+
+  .#{$prefix}--side-nav__icon svg {
+    fill: $ui-01;
+  }
+}
+
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  > .#{$prefix}--side-nav__submenu,
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__menu[role='menu']
+  a.#{$prefix}--side-nav__link[role='menuitem']:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active):hover
+  > .#{$prefix}--side-nav__link {
+  background-color: #e5e5e5;
+  color: $text-01;
+
+  .#{$prefix}--side-nav__link-text {
+    color: $text-01;
+  }
+
+  .#{$prefix}--side-nav__icon svg {
+    fill: $text-01;
+  }
+}
+
+.#{$prefix}--side-nav
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__submenu[aria-expanded='true'] {
+  background-color: $ui-05;
+  color: $active-01;
+
+  &:hover {
+    background-color: #353535;
+    color: $ui-01;
+
+    .#{$prefix}--side-nav__icon svg {
+      fill: $ui-01;
+    }
+  }
+
+  .#{$prefix}--side-nav__icon svg {
+    fill: $active-01;
+  }
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__item
+  .#{$prefix}--side-nav__submenu[aria-expanded='true'] {
+  background-color: $ui-02;
+  color: $text-02;
+
+  &:hover {
+    background-color: #e5e5e5;
+    color: $text-01;
+
+    .#{$prefix}--side-nav__icon svg {
+      fill: $text-01;
+    }
+  }
+
+  .#{$prefix}--side-nav__icon svg {
+    fill: $text-02;
+  }
+}
+
+.#{$prefix}--side-nav a.#{$prefix}--side-nav__link[aria-current='page'],
+.#{$prefix}--side-nav__menu[role='menu'] a.#{$prefix}--side-nav__link--current,
+.#{$prefix}--side-nav__menu[role='menu']
+  a.#{$prefix}--side-nav__link[aria-current='page'] {
+  background-color: $carbon--gray-80;
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website--light
+  a.#{$prefix}--side-nav__link[aria-current='page'],
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__menu[role='menu']
+  a.#{$prefix}--side-nav__link--current,
+.#{$prefix}--side-nav--website--light
+  .#{$prefix}--side-nav__menu[role='menu']
+  a.#{$prefix}--side-nav__link[aria-current='page'] {
+  background-color: $ui-03;
+}
+
+.#{$prefix}--side-nav a.#{$prefix}--side-nav__link,
+.#{$prefix}--side-nav__submenu[aria-haspopup='true'] {
+  min-height: 2rem;
+  height: 2rem;
+}
+
+.#{$prefix}--side-nav .#{$prefix}--side-nav__icon,
+.#{$prefix}--side-nav .#{$prefix}--side-nav__icon svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.#{$prefix}--side-nav__submenu > .#{$prefix}--side-nav__icon,
+a.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__icon {
+  margin-right: 0;
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website + div::before {
+  content: '';
+  visibility: hidden;
+  opacity: 0;
+  will-change: opacity;
+  transition: $transition--expansion opacity $carbon--standard-easing,
+    $transition--expansion visibility $carbon--standard-easing;
+  background: $overlay-01;
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  z-index: 100;
+}
+
+.#{$prefix}--side-nav.#{$prefix}--side-nav--website:not(.side-nav__closed) {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+
+  & + div {
+    position: fixed;
+  }
+
+  & + div::before {
+    opacity: 1;
+    visibility: initial;
+  }
+
+  @include carbon--breakpoint('lg') {
+    & + div {
+      position: inherit;
+    }
+
+    & + div::before {
+      visibility: hidden;
+      opacity: 0;
+    }
+  }
+}

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { WebsiteBackToTopBtn } from '@carbon/addons-website';
 import slugify from 'slugify';
 import { useStaticQuery, graphql } from 'gatsby';
 
 import { useScrollDirection } from '../util/hooks';
 
+import BackToTopBtn from '../components/BackToTopBtn';
 import Layout from '../components/Layout';
 import PageHeader from '../components/PageHeader';
 import EditLink from '../components/EditLink';
@@ -69,7 +69,7 @@ const Default = ({ pageContext, children, location }) => {
         tabs={tabs}
         currentTab={currentTab}
       />
-      <WebsiteBackToTopBtn />
+      <BackToTopBtn />
     </Layout>
   );
 };

--- a/packages/gatsby-theme-carbon/src/templates/Homepage.js
+++ b/packages/gatsby-theme-carbon/src/templates/Homepage.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { WebsiteBackToTopBtn } from '@carbon/addons-website';
 import Layout from '../components/Layout';
 import { HomepageBanner, HomepageCallout } from '../components/Homepage';
 import Carbon from '../images/carbon.jpg';
 import Main from '../components/Main';
 
+import BackToTopBtn from '../components/BackToTopBtn';
 import NextPrevious from '../components/NextPrevious';
 
 const Homepage = ({
@@ -30,7 +30,7 @@ const Homepage = ({
       <Main>{children}</Main>
       {SecondCallout}
       <NextPrevious location={location} pageContext={pageContext} />
-      <WebsiteBackToTopBtn />
+      <BackToTopBtn />
     </Layout>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,7 +247,7 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
-"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.3.4":
+"@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz#a974cfae1e37c3110e71f3c6a2e48b8e71958cd4"
   integrity sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==
@@ -763,24 +763,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@carbon/addons-website@0.0.1-alpha.21":
-  version "0.0.1-alpha.21"
-  resolved "https://registry.yarnpkg.com/@carbon/addons-website/-/addons-website-0.0.1-alpha.21.tgz#c7f08273778da206685ac37147634845ae3260ad"
-  integrity sha512-EbVcRz6TP4wH/g8OEpzA0P7MY3xiaAurGo5F2XzlGj4r5YQaAH+r5QUrtzAvrzEWibtyMVCDUJwG74wtoT4Rqw==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.3.4"
-    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
-    "@carbon/grid" "10.1.1"
-    "@carbon/layout" "10.1.1"
-    "@ibm/plex" "^1.4.1"
-    babel-loader "^8.0.5"
-    classnames "^2.2.6"
-    lodash.throttle "^4.1.1"
-    prismjs "^1.15.0"
-    react-copy-to-clipboard "^5.0.1"
-    react-scroll-up "^1.3.3"
-    react-textarea-autosize "^7.1.0"
-
 "@carbon/colors@10.3.0":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.3.0.tgz#99df98f141c6d3a237d72ac9b21ad58a07112348"
@@ -799,14 +781,6 @@
     "@carbon/motion" "10.3.0"
     "@carbon/themes" "10.4.0"
     "@carbon/type" "10.3.0"
-
-"@carbon/grid@10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-10.1.1.tgz#f7e6322d2adb2b3f7276f135f6f634e50df37222"
-  integrity sha512-tI9yTX4Hr97i2+Za+Pu4vLJj62AmNrV0OMP7iqL+uTwhlEkwjrJIT2aiVy7lX8LLwhPyX7YnGzCdWpaV/S/ofw==
-  dependencies:
-    "@carbon/import-once" "10.1.0"
-    "@carbon/layout" "10.1.1"
 
 "@carbon/grid@10.4.0":
   version "10.4.0"
@@ -833,20 +807,10 @@
   resolved "https://registry.yarnpkg.com/@carbon/icons/-/icons-10.4.0.tgz#38bf0b57edb5ffd07ad6f73bf2a833823ab8bc56"
   integrity sha512-ZKaz29giJ/ToVEIYQ5TaPXbSj9ruhfDTmZG/QvQuClV3oxIBk7psQDRANpfOZ7QHAyu1VwQJzx7BidLkbAeTSQ==
 
-"@carbon/import-once@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@carbon/import-once/-/import-once-10.1.0.tgz#dc6d06d45f77c24461a1a4d48d90f6ba63622f3f"
-  integrity sha512-cZTifeQvvYKDSJ/arFPXF/tLOz8jn2tmp+ukCAL6n/J1flz3fYIwq9L1R0RyzRJTiKA5f+bT7wYW62xDqrOOnw==
-
 "@carbon/import-once@10.3.0":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@carbon/import-once/-/import-once-10.3.0.tgz#58617da4efb6d7a11352d8e6b7209da1d39f364d"
   integrity sha512-PFk3FhMe3psihYtCg3JsyPHismqglnbUqIpz1DCG5Gn/kt0HdVKhGvHdEq7E305rGoBUCKzMn/4xoY9v9mcmlg==
-
-"@carbon/layout@10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-10.1.1.tgz#06608c451b222ee89abe3753cca6990690127af2"
-  integrity sha512-FC5iOJLR2CwG5gJX5Wz6jpFCdiLOsKaCw949+t3waWRhdb1CJ9B3PDXM8KUOKRuwo4tsXQb2kd8wXkGNfdkWTw==
 
 "@carbon/layout@10.3.0":
   version "10.3.0"
@@ -1122,11 +1086,6 @@
   integrity sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==
   dependencies:
     "@hapi/hoek" "8.x.x"
-
-"@ibm/plex@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@ibm/plex/-/plex-1.4.1.tgz#daed951f4c5bbdef698c184abb78dcc3de13223a"
-  integrity sha512-Sq6TBdApZV+y4kOstaVoGy2wIxboJnyzwESMcaRbC9+kMO/5Z0sxapQmQb0foKyLVRRsmn5LEA5LeVsncFsLwA==
 
 "@jimp/bmp@^0.6.4":
   version "0.6.4"
@@ -3171,7 +3130,7 @@ babel-eslint@^9.0.0:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babel-loader@^8.0.0, babel-loader@^8.0.5:
+babel-loader@^8.0.0:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
   integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
@@ -4730,7 +4689,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3, copy-to-clipboard@^3.2.0:
+copy-to-clipboard@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
   integrity sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==
@@ -12690,7 +12649,7 @@ prism-react-renderer@^0.1.7:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-0.1.7.tgz#dc273d0cb6e4a498ba0775094e9a8b01a3ad2eaa"
   integrity sha512-EhnM0sYfLK103ASK0ViSv0rta//ZGB0dBA9TiFyOvA+zOj5peLmGEG01sLEDwl9sMe+gSqncInafBe1VFTCMvA==
 
-prismjs@^1.15.0, prismjs@^1.8.4, prismjs@~1.17.0:
+prismjs@^1.8.4, prismjs@~1.17.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
   integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
@@ -12769,7 +12728,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12993,14 +12952,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-copy-to-clipboard@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
-  integrity sha512-ELKq31/E3zjFs5rDWNCfFL4NvNFQvGRoJdAKReD/rUPA+xxiLPQmZBZBvy2vgH7V0GE9isIQpT9WXbwIVErYdA==
-  dependencies:
-    copy-to-clipboard "^3"
-    prop-types "^15.5.8"
-
 react-dev-utils@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"
@@ -13124,14 +13075,6 @@ react-syntax-highlighter@^11.0.2:
     lowlight "~1.11.0"
     prismjs "^1.8.4"
     refractor "^2.4.1"
-
-react-textarea-autosize@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
-  integrity sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.6.0"
 
 react@^16.8.0, react@^16.8.4, react@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
Brings in BackToTopBtn component, grid additions and shell overrides to this repo. This removes our dependency on the deprecated @carbon/addons-website package. 

### Testing
- Make sure UI Shell looks correct (side nav/header)
- Make sure back to top button looks correct
- Make sure grid component gutter classes are being applied correctly
