### PR TITLE
fix(docs): remove stray backtick

### DIFF
--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -85,7 +85,7 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
     >
       ![Github icon](/images/github-icon.png)
     </ResourceCard>
-  </Column>`
+  </Column>
 </Row>
 ```
 


### PR DESCRIPTION
## Description

Removed stray backtick in `ResourceCard` code block