### PR TITLE
fix: article card type style and caption spacing

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLinks.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLinks.module.scss
@@ -30,7 +30,7 @@
   position: relative;
   display: inline-block;
   transition: color $transition--base;
-  color: $interactive-02;
+  color: $carbon--gray-100;
   text-decoration: none;
   margin-bottom: $spacing-03;
   margin-left: $spacing-06;

--- a/packages/gatsby-theme-carbon/src/components/ArticleCard/article-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ArticleCard/article-card.scss
@@ -30,12 +30,15 @@
 }
 
 .#{$prefix}--article-card__info {
-  @include carbon--type-style('caption-01');
   position: absolute;
   bottom: 1rem;
   left: 1rem;
   padding: 0;
   color: $text-02;
+}
+
+.#{$prefix}--article-card__info p {
+  @include carbon--type-style('caption-01');
 }
 
 .#{$prefix}--article-card__img .gatsby-resp-image-wrapper {

--- a/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
+++ b/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
@@ -12,7 +12,7 @@ img + .#{$prefix}--caption {
 
 // Caption after video
 div[class^='Video-module--video'] + .#{$prefix}--caption {
-  margin-top: -4rem;
+  margin-top: -$layout-05;
 }
 
 // Responsive by default

--- a/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
+++ b/packages/gatsby-theme-carbon/src/components/Caption/caption.scss
@@ -11,8 +11,8 @@ img + .#{$prefix}--caption {
 }
 
 // Caption after video
-[class^='Video-module--video'] + .#{$prefix}--caption {
-  margin-top: -$spacing-08;
+div[class^='Video-module--video'] + .#{$prefix}--caption {
+  margin-top: -4rem;
 }
 
 // Responsive by default


### PR DESCRIPTION
- type size broke on article cards w/ latest Carbon - fixed
- updates spacing for captions below video
- token color change broke anchor link color - fixed  ref #369