### PR TITLE
fix(Switcher): change width and border-bottom

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
@@ -3,14 +3,13 @@
   z-index: 10000;
   position: fixed;
   right: 0;
-  top: 47px;
+  top: 48px;
   height: 100%;
   width: 16rem;
   background-color: $ui-05;
   border-left: 1px solid $inverse-02;
   transform: translateX(16rem);
   overflow-y: hidden;
-  border-bottom: 1px solid $inverse-02;
   transition: all $duration--fast-02 carbon--motion('exit');
   @include carbon--breakpoint('lg') {
     transform: translateX(0);


### PR DESCRIPTION
Closes #357 

- updates the width of the nav from `48px` to `47px` tp remove the 1px overhang 
- changes the border from transparent to $inverse-02 so the border matches the rest of the bar.  

Testing: check that the Switcher is no longer 1 px off and that the border matches the rest of the nav bar