### PR TITLE
fix: add path prefix to poster

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Video/Video.js
+++ b/packages/gatsby-theme-carbon/src/components/Video/Video.js
@@ -12,7 +12,7 @@ import {
   videoIsPlaying,
 } from './Video.module.scss';
 
-const Video = ({ vimeoId, title, src, ...props }) => {
+const Video = ({ vimeoId, title, src, poster, ...props }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const videoRef = useRef(null);
   const iframeRef = useRef(null);
@@ -191,6 +191,7 @@ const Video = ({ vimeoId, title, src, ...props }) => {
         controls
         onEnded={onEnded}
         src={withPrefix(src)}
+        poster={withPrefix(poster)}
         {...props}
       />
     </div>


### PR DESCRIPTION
#383 but for the poster images

Asset's are 404ing because we look for them at the root directory (ibm.com) instead of the prefixed path (ibm.com/design/language).

