### PR TITLE
fix: Add switcher drop shadow closes #388

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
@@ -37,6 +37,7 @@
     // Tied to the height of the app switcher. Allows for animating up to auto.
     // Matching the height exactly is imperitive to keep the correct animation timing.
     max-height: 458px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
   }
 }
 

--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
@@ -37,7 +37,7 @@
     // Tied to the height of the app switcher. Allows for animating up to auto.
     // Matching the height exactly is imperitive to keep the correct animation timing.
     max-height: 458px;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5); // header__menu shadow
   }
 }
 


### PR DESCRIPTION
closes #388 

Note: rather than the type component I used the shadows from the shell menu dropdowns: http://react.carbondesignsystem.com/?path=/story/ui-shell--header-base-w-navigation