### PR TITLE
feat(ResourceCard): add a blue background variation

### DIFF
--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -41,7 +41,7 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       subTitle="Alternate color"
       title="Dark"
       aspectRatio="2:1"
-      color="dark"
+      color="blue"
       actionIcon="email"
       href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
       >

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -41,7 +41,7 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       subTitle="Alternate color"
       title="Dark"
       aspectRatio="2:1"
-      color="blue"
+      color="dark"
       actionIcon="email"
       href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
       >

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -42,7 +42,6 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       title="Dark"
       aspectRatio="2:1"
       color="dark"
-      disabled
       actionIcon="email"
       href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
       >

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -42,6 +42,7 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       title="Dark"
       aspectRatio="2:1"
       color="dark"
+      disabled
       actionIcon="email"
       href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
       >
@@ -160,6 +161,6 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
 | title       | string   |          |          | Large title                                                                                         |
 | actionIcon  | string   |          | `launch` | Action icon, default is launch, options are `launch`, `arrowRight`, `download`, `disabled`, `email` |
 | aspectRatio | string   |          | 2:1      | Set card aspect ratio, default is 2:1, options are 1:1, 16:9, 4:3                                   |
-| color       | string   |          | light    | Set to `dark` for dark background                                                                   |
+| color       | string   |          | light    | Set to `dark` for dark background. Set to `blue` for blue background.                               |
 | disabled    | bool     |          | false    | Set for disabled card                                                                               |
 | className   | string   |          |          | Add custom class name                                                                               |

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/ResourceCard.js
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/ResourceCard.js
@@ -87,6 +87,7 @@ export default class ResourceCard extends React.Component {
       [className]: className,
       [`${prefix}--resource-card--disabled`]: disabled,
       [`${prefix}--resource-card--dark`]: color === 'dark',
+      [`${prefix}--resource-card--blue`]: color === 'blue',
     });
 
     const aspectRatioClassNames = classnames([`${prefix}--aspect-ratio`], {

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
@@ -16,7 +16,7 @@
 }
 
 .resource-card-group .#{$prefix}--resource-card--blue {
-  border-top-color: $carbon--blue-90;
+  border-top-color: $carbon--blue-80;
 }
 
 .resource-card-group

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card-group.scss
@@ -15,6 +15,10 @@
   border-top-color: $carbon--black-100;
 }
 
+.resource-card-group .#{$prefix}--resource-card--blue {
+  border-top-color: $carbon--blue-90;
+}
+
 .resource-card-group
   .#{$prefix}--col-lg-4:nth-child(2)
   .#{$prefix}--resource-card {
@@ -49,6 +53,12 @@
   .#{$prefix}--col-lg-4:nth-child(even)
   .#{$prefix}--resource-card--dark {
   border-left-color: $carbon--black-100;
+}
+
+.resource-card-group
+  .#{$prefix}--col-lg-4:nth-child(even)
+  .#{$prefix}--resource-card--blue {
+  border-left-color: $carbon--blue-90;
 }
 
 // Set spacing to the right of the group

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -128,3 +128,22 @@
   svg {
   fill: $carbon--gray-70; //$disabled-02 for gray 90
 }
+
+// Disabled blue
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--blue
+  .#{$prefix}--tile:hover {
+  background: $carbon--blue-60;
+}
+
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--blue
+  .#{$prefix}--resource-card__title,
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--blue
+  .#{$prefix}--resource-card__subtitle {
+  color: $carbon--gray-30;
+}
+
+.#{$prefix}--resource-card--disabled.#{$prefix}--resource-card--blue
+  .#{$prefix}--resource-card__icon--action
+  svg {
+  fill: $carbon--gray-30;
+}

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -70,6 +70,24 @@
   fill: $carbon--gray-10; //$icon-01 for grsay 90 theme
 }
 
+// Blue
+.#{$prefix}--resource-card--blue .#{$prefix}--tile {
+  background: $carbon--blue-60;
+}
+
+.#{$prefix}--resource-card--blue .#{$prefix}--tile:hover {
+  background: $carbon--blue-70;
+}
+
+.#{$prefix}--resource-card--blue .#{$prefix}--resource-card__title,
+.#{$prefix}--resource-card--blue .#{$prefix}--resource-card__subtitle {
+  color: $text-04;
+}
+
+.#{$prefix}--resource-card--blue .#{$prefix}--resource-card__icon--action svg {
+  fill: $carbon--white-0;
+}
+
 // Disabled
 .#{$prefix}--resource-card--disabled .#{$prefix}--tile:hover {
   background: $ui-background;


### PR DESCRIPTION
Updated the ResourceCard component to include a blue60 background with a blue70 hover.