### PR TITLE
feat: add prepend option to titleType

### DIFF
--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -170,6 +170,7 @@ To add a link to the bottom of each page that points to the current page source 
   - `page`: "Configuration" (default)
   - `site`: "Gatsby Theme Carbon"
   - `append`: "Gatsby Theme Carbon – Configuration"
+  - `prepend`: "Configuration - Gatsby Theme Carbon"
 
 ```js
 plugins: [

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -15,7 +15,7 @@ const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
       case 'append':
         return `${title}${pageTitle ? ` – ${pageTitle}` : ''}`;
       case 'prepend':
-        return `${pageTitle}${pageTitle ? ` – ${title}` : ''}`;
+        return `${pageTitle ? `${pageTitle} – ` : ''}${title}`;
       default:
         return null;
     }

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -14,6 +14,8 @@ const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
         return title;
       case 'append':
         return `${title}${pageTitle ? ` – ${pageTitle}` : ''}`;
+      case 'prepend':
+        return `${pageTitle}${pageTitle ? ` – ${title}` : ''}`;
       default:
         return null;
     }


### PR DESCRIPTION
closes #403 

Adds option to prepend the title before the site name 

`prepend`: "Configuration - Gatsby Theme Carbon"