### PR TITLE
[Search] add tab to distinguish pages with the same title

### DIFF
--- a/packages/example/src/pages/guides/navigation/sidebar.mdx
+++ b/packages/example/src/pages/guides/navigation/sidebar.mdx
@@ -1,7 +1,7 @@
 ---
 title: Navigation
 tabs: ['Sidebar', 'Tabs']
-description: Sidebar - guide for adding and maintaining the sidebar entries
+description: guide for adding and maintaining the sidebar entries
 ---
 
 <PageDescription>

--- a/packages/example/src/pages/guides/navigation/tabs.mdx
+++ b/packages/example/src/pages/guides/navigation/tabs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Navigation
 tabs: ['Sidebar', 'Tabs']
-description: Tabs - guide for building a page using tab navigation
+description: guide for building a page using tab navigation
 ---
 
 <PageDescription>

--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.module.scss
@@ -73,8 +73,13 @@
   padding: 0;
 }
 
+.tab {
+  text-transform: capitalize;
+}
+
 .description {
   @include carbon--type-style('caption-01');
+  text-transform: lowercase;
   color: $carbon--gray-30;
 }
 

--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
@@ -7,6 +7,7 @@ import {
   description,
   active,
   hidden,
+  tab,
 } from './GlobalSearch.module.scss';
 
 export const MenuContext = createContext();
@@ -23,6 +24,23 @@ const Menu = ({ results, onKeyDown }) => {
   // Results must at least have a title to show up in the list
   const filteredResults = results.filter(result => result.title);
 
+  // In the event two pages have the same title, we need to add a tab to distinguish them in the results list
+  const resultsWithTabAdded = filteredResults.map(result => {
+    const matchingResults = filteredResults.filter(
+      otherResult => otherResult.title === result.title
+    );
+    if (matchingResults.length > 1) {
+      return {
+        ...result,
+        tab: result.path
+          .split('/')
+          .filter(Boolean) // handles empty strings from trailing slash in path
+          .pop(),
+      };
+    }
+    return result;
+  });
+
   return (
     <>
       <ul
@@ -33,7 +51,7 @@ const Menu = ({ results, onKeyDown }) => {
           [hidden]: results.length === 0,
         })}
       >
-        {filteredResults.map((page, index) => (
+        {resultsWithTabAdded.map((page, index) => (
           <MenuItem
             id={`menu-item-${index}`}
             onKeyDown={onKeyDown}
@@ -69,10 +87,11 @@ const MenuItem = ({ page, index, onKeyDown, id }) => {
         className={className}
         to={page.path}
       >
-        {`${page.title} – `}
-        <span className={description}>
-          {page.description && page.description.toLowerCase()}
-        </span>
+        {page.title}&nbsp;
+        {page.tab && <span className={tab}>→ {page.tab} </span>}
+        {page.description && (
+          <span className={description}>– {page.description}</span>
+        )}
       </Link>
     </li>
   );


### PR DESCRIPTION
Pages with tabs could share the same title. If this is the case, we can add the last bit of path as an identifier to set them apart.

`→` character got okayed by @designertyler 

**You can search for “Navigation” to see it working**