### PR TITLE
[Search]: fix poor search results

### DIFF
--- a/packages/gatsby-theme-carbon/config/lunr-options.js
+++ b/packages/gatsby-theme-carbon/config/lunr-options.js
@@ -1,29 +1,30 @@
-const getFrontmatter = (node, item) => {
-  if (node.context && node.context.frontmatter) {
-    return node.context.frontmatter[item];
-  }
-  return '';
+const removeStemmerPlugin = lunr => builder => {
+  builder.pipeline.remove(lunr.stemmer);
+  builder.searchPipeline.remove(lunr.stemmer);
 };
 
 module.exports = {
-  languages: [{ name: 'en' }],
+  languages: [
+    {
+      name: 'en',
+      filterNodes: node => node.context && node.context.MdxNode,
+      plugins: [removeStemmerPlugin],
+    },
+  ],
   fields: [
-    { name: 'title', store: true, attributes: { boost: 20 } },
-    { name: 'keywords', attributes: { boost: 5 } },
+    { name: 'title', store: true, attributes: { boost: 30 } },
+    { name: 'keywords' },
     { name: 'path', store: true },
     { name: 'description', store: true },
     { name: 'content' },
   ],
   resolvers: {
     SitePage: {
-      title: node => getFrontmatter(node, 'title'),
       path: node => node.path,
-      description: node => getFrontmatter(node, 'description'),
-      keywords: node => getFrontmatter(node, 'keywords'),
-      content: node =>
-        node.context && node.context.MdxNode
-          ? node.context.MdxNode.internal.content
-          : '',
+      title: node => node.context.frontmatter.title,
+      description: node => node.context.frontmatter.description,
+      keywords: node => node.context.frontmatter.keywords,
+      content: node => node.context.MdxNode.internal.content,
     },
   },
 };


### PR DESCRIPTION
closes #413 

This removes the [Lunr stemmer](https://www.gatsbyjs.org/packages/gatsby-plugin-lunr/#using-plugins) which is goofing up our search index and search results.

**Testing:** search for "Navigation" or any other full page title at https://gatsby-theme-carbon.now.sh and compare to this deploy preview. 

We should now show results throughout the user typing interaction rather than randomly empty results in the middle and end.