### PR TITLE
fix: manage focus with escape clear

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
@@ -122,6 +122,7 @@ const GlobalSearchInput = () => {
           clearAndClose();
         } else {
           setQuery('');
+          setIsManagingFocus(true);
           inputRef.current.focus();
         }
         break;


### PR DESCRIPTION
If escape is used to clear, we don't properly set manage focus state even though we direct focus to the input. This results in us failing to focus the search button correctly on close.