### PR TITLE
chore: add gtc version meta tag

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-ssr.js
+++ b/packages/gatsby-theme-carbon/gatsby-ssr.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 import wrapRoot from './src/util/wrap-root-element';
+import { version } from './package.json';
 
 export const wrapRootElement = wrapRoot;
 
@@ -26,5 +27,6 @@ export const onRenderBody = ({ setHeadComponents }) => {
       key="scroll-loader-script"
       dangerouslySetInnerHTML={{ __html: script }}
     />,
+    <meta key="gtc-version" name="gtc-version" content={version} />,
   ]);
 };


### PR DESCRIPTION
This allows us to easily check which version of gtc a site is using.