### PR TITLE
fix(navigation): fix page tabs replace bug

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
@@ -28,7 +28,8 @@ export default class PageTabs extends React.Component {
     const pageTabs = tabs.map(tab => {
       const slugifiedTab = slugify(tab, { lower: true });
       const selected = slugifiedTab === currentTab;
-      const href = slug.replace(currentTab, slugifiedTab);
+      const lastWordRegex = new RegExp(`${currentTab}$`);
+      const href = slug.replace(lastWordRegex, slugifiedTab);
       return (
         <li key={tab} className={cx({ [selectedItem]: selected }, listItem)}>
           <Link className={link} to={`${href}`}>

--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
@@ -28,7 +28,9 @@ export default class PageTabs extends React.Component {
     const pageTabs = tabs.map(tab => {
       const slugifiedTab = slugify(tab, { lower: true });
       const selected = slugifiedTab === currentTab;
-      const lastWordRegex = new RegExp(`${currentTab}$`);
+      // foo(?!-) negative lookahead => matches string if it's not followed by -
+      const slash = '/';
+      const lastWordRegex = new RegExp(`${currentTab}(?!-)`);
       const href = slug.replace(lastWordRegex, slugifiedTab);
       return (
         <li key={tab} className={cx({ [selectedItem]: selected }, listItem)}>

--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.js
@@ -28,8 +28,6 @@ export default class PageTabs extends React.Component {
     const pageTabs = tabs.map(tab => {
       const slugifiedTab = slugify(tab, { lower: true });
       const selected = slugifiedTab === currentTab;
-      // foo(?!-) negative lookahead => matches string if it's not followed by -
-      const slash = '/';
       const lastWordRegex = new RegExp(`${currentTab}(?!-)`);
       const href = slug.replace(lastWordRegex, slugifiedTab);
       return (


### PR DESCRIPTION
Closes #320 

As-is: page tabs navigation works by replacing the `currentTab` with the `slugifiedTab` that is selected:

```js
const href = slug.replace(currentTab, slugifiedTab);
```

`currentTab` is a string. This works fine if there are no other strings that match that string. However, if there are more than one instances of this string, it'll replace the first match, regardless of if its the correct one or not. This is causing a bug on our website. Specifically the Code snippet page. When you click on the `usage` tab, the `href` replaces the wrong `code` string:
first tab:
```
https://www.carbondesignsystem.com/components/code-snippet/code/
```

second tab url (broken):
```
https://www.carbondesignsystem.com/components/usage-snippet/code/
```

```
should be:
https://www.carbondesignsystem.com/components/code-snippet/usage/
```

#### Changelog

**Changed**

- replaces string variable with regex, so the right string is being replaced
- uses negative lookahead to make sure the string isn't followed by `-` given that there is never a `-` at the end of a slug.
   - this is assuming that if there is a `-` at the end of the string, it's likely not matching to the correct string since there is more to the slug than was matched (i.e. how `usage` changes `code-snippet` with `usage-snippet`)
```js
    // string(?!-) negative lookahead => matches string if it's not followed by -
```

**Reviewers**
- ensure regex looks correct (this is my first time writing one 😬)