### PR TITLE
docs: update markdown docs

### DIFF
--- a/packages/example/src/pages/components/ArticleCard.mdx
+++ b/packages/example/src/pages/components/ArticleCard.mdx
@@ -93,6 +93,13 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
 
 ## Code
 
+<InlineNotification>
+
+**Note:** Images will not render if there is any extra whitespace in the lines above/below or before the image. 
+We reccomend using an editor where you can show whitespace to help.
+
+</InlineNotification>
+
 ```jsx path=components/ArticleCard/ArticleCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ArticleCard
 <Row>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -104,7 +111,8 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       readTime="Read time: 5 min"
       href="/"
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
     </ArticleCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -114,7 +122,9 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       href="https://www.ibm.com"
       actionIcon="arrowRight"
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
+
     </ArticleCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -123,7 +133,9 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       href="https://www.ibm.com"
       disabled
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
+
     </ArticleCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -133,7 +145,9 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       href="https://www.ibm.com"
       actionIcon="download"
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
+
     </ArticleCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -145,7 +159,9 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       href="https://www.ibm.com"
       actionIcon="email"
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
+
     </ArticleCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterMdLeft>
@@ -157,7 +173,9 @@ The `<ArticleCard>` component should generally be used inside of a `<Row>` and `
       color="dark"
       disabled
     >
-      ![Dark article layout mockup](/images/Article_05.png)
+
+![Dark article layout mockup](/images/Article_05.png)
+
     </ArticleCard>
   </Column>
 </Row>

--- a/packages/example/src/pages/components/DoDontExample.mdx
+++ b/packages/example/src/pages/components/DoDontExample.mdx
@@ -48,7 +48,9 @@ The `<DoDontExample>` component will generally need to be placed inside `<Row>` 
 
 ```jsx path=components/DoDontExample/DoDontExample.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/DoDontExample
 <DoDontExample type="do" captionTitle="Caption title" caption="Caption">
-  ![Alt text](images/light-theme.png)
+
+![Alt text](images/light-theme.png)
+
 </DoDontExample>
 ```
 

--- a/packages/example/src/pages/components/FeatureCard.mdx
+++ b/packages/example/src/pages/components/FeatureCard.mdx
@@ -37,6 +37,13 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
 
 ## Code
 
+<InlineNotification>
+
+**Note:** Images will not render if there is any extra whitespace in the lines above/below or before the image. 
+We reccomend using an editor where you can show whitespace to help.
+
+</InlineNotification>
+
 ```jsx path=components/FeatureCard/FeatureCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/FeatureCard
 <FeatureCard
   subTitle="With subtitle"
@@ -46,7 +53,9 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
   disabled
   color="dark"
 >
-  ![demo image](/images/large-image.png)
+
+![demo image](/images/large-image.png)
+
 </FeatureCard>
 ```
 

--- a/packages/example/src/pages/components/ImageCard.mdx
+++ b/packages/example/src/pages/components/ImageCard.mdx
@@ -75,12 +75,21 @@ The `<ImageCard>` component should generally be used inside of a `<Row>` and `<C
 
 ## Code
 
+<InlineNotification>
+
+**Note:** Images will not render if there is any extra whitespace in the lines above/below or before the image. 
+We reccomend using an editor where you can show whitespace to help.
+
+</InlineNotification>
+
 ```jsx path=components/ImageCard/ImageCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ImageCard
 <Row className="image-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ImageCard title="Title" subTitle="Subtitle" href="/">
-      ![Square](/images/square.png)
+
+![Square](/images/square.png)
     </ImageCard>
+
     <ImageCard
       title="Dark title"
       titleColor="dark"
@@ -90,7 +99,9 @@ The `<ImageCard>` component should generally be used inside of a `<Row>` and `<C
       subTitleColor="light"
       subTitle="Light subtitle"
     >
-      ![Light dark](./images/light-dark.jpg)
+
+![Light dark](./images/light-dark.jpg)
+
     </ImageCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
@@ -103,15 +114,21 @@ The `<ImageCard>` component should generally be used inside of a `<Row>` and `<C
       titleColor="light"
       subTitleColor="light"
     >
-      ![Plane image](./images/plane.jpg)
+
+![Plane image](./images/plane.jpg)
+
     </ImageCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ImageCard aspectRatio="1:1" href="/" hoverColor="dark">
-      ![color pallete array](/images/color-grid.svg)
+
+![color pallete array](/images/color-grid.svg)
+
     </ImageCard>
     <ImageCard disabled aspectRatio="1:1" href="/">
-      ![Square](/images/square.png)
+
+![Square](/images/square.png)
+
     </ImageCard>
   </Column>
 </Row>

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -67,6 +67,13 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
 
 ## Code
 
+<InlineNotification>
+
+**Note:** Images will not render if there is any extra whitespace in the lines above/below or before the image. 
+We reccomend using an editor where you can show whitespace to help.
+
+</InlineNotification>
+
 #### Group
 
 ```jsx path=components/ResourceCard/ResourceCard.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/master/packages/gatsby-theme-carbon/src/components/ResourceCard
@@ -76,7 +83,9 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       subTitle="Carbon Design System"
       href="https://www.carbondesignsystem.com"
     >
-      ![Github icon](/images/github-icon.png)
+
+![Github icon](/images/github-icon.png)
+
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
@@ -84,7 +93,9 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
       subTitle="Carbon Design System"
       href="https://www.carbondesignsystem.com"
     >
-      ![Github icon](/images/github-icon.png)
+
+![Github icon](/images/github-icon.png)
+
     </ResourceCard>
   </Column>
 </Row>
@@ -101,7 +112,9 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
     actionIcon="arrowRight"
     href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
   >
-    ![Github icon](/images/github-icon.png)
+
+![Github icon](/images/github-icon.png)
+
   </ResourceCard>
 </Column>
 ```
@@ -116,7 +129,9 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
     aspectRatio="2:1"
     href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
   >
-    ![Github icon](/images/github-icon.png)
+
+![Github icon](/images/github-icon.png)
+
   </ResourceCard>
 </Column>
 ```
@@ -133,7 +148,9 @@ The `<ResourceCard>` component should be wrapped with a `<Column>` inside of `<R
     actionIcon="email"
     href="https://github.com/IBM/carbon-elements/blob/master/.github/CONTRIBUTING.md"
   >
-    ![Sketch icon](/images/sketch-icon.png)
+
+![Sketch icon](/images/sketch-icon.png)
+
   </ResourceCard>
 </Column>
 ```


### PR DESCRIPTION
Adds a note to card component pages about warning about whitespace. 
Updates formatting in examples (had to turn off prettier to get this to not format, couldn't figure out how to ignore??)