### PR TITLE
fix: export InlineNotification

### DIFF
--- a/packages/gatsby-theme-carbon/index.js
+++ b/packages/gatsby-theme-carbon/index.js
@@ -13,6 +13,8 @@ export { default as FeatureCard } from './src/components/FeatureCard';
 export { default as FourOhFour } from './src/components/FourOhFour';
 export { default as ImageCard } from './src/components/ImageCard';
 export { Tabs, Tab } from './src/components/Tabs';
-
+export {
+  default as InlineNotification,
+} from './src/components/InlineNotification';
 // Homepage Template Components
 export { HomepageCallout, HomepageBanner } from './src/components/Homepage';


### PR DESCRIPTION
This exports `InlineNotification` from the main module.

Now this works:

```js
import {InlineNotification} from 'gatsby-theme-carbon';
```