### PR TITLE
fix(EditLink): Adds branch option to edit url

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -25,6 +25,7 @@ module.exports = {
           baseUrl:
             'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
+          branch: 'master',
         },
       },
     },

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -25,7 +25,6 @@ module.exports = {
           baseUrl:
             'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
-          branch: 'master',
         },
       },
     },

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -137,7 +137,15 @@ To do so, provide your own [resolvers object](https://www.gatsbyjs.org/packages/
 
 ## Edit on GitHub link
 
-To add a link to the bottom of each page that points to the current page source in GitHub, provide an `repository` object to `siteMetadata` in your `gatsby-config.js` file. You can provide a `baseUrl`, and if needed, the `subDirectory` where your site source lives.
+To add a link to the bottom of each page that points to the current page source in GitHub, provide an `repository` object to `siteMetadata` in your `gatsby-config.js` file. You can provide a `baseUrl`, and if needed, the `subDirectory` and `branch` where your site source lives.
+
+<InlineNotification>
+
+To get this to work you will need to supply values to all 3 nodes of `repository` (`baseUrl`, `subDirectory`, and `branch`) for this to link correctly.
+
+Even if you have no `subDirectory` an empty string `''` must be supplied.
+
+</InlineNotification>
 
 ```js
   plugins: [
@@ -147,6 +155,7 @@ To add a link to the bottom of each page that points to the current page source 
         repository: {
           baseUrl: 'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
+          branch: 'master',
         },
       },
     },

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -137,15 +137,7 @@ To do so, provide your own [resolvers object](https://www.gatsbyjs.org/packages/
 
 ## Edit on GitHub link
 
-To add a link to the bottom of each page that points to the current page source in GitHub, provide an `repository` object to `siteMetadata` in your `gatsby-config.js` file. You can provide a `baseUrl`, and if needed, the `subDirectory` and `branch` where your site source lives.
-
-<InlineNotification>
-
-To get this to work you will need to supply values to all 3 nodes of `repository` (`baseUrl`, `subDirectory`, and `branch`) for this to link correctly.
-
-Even if you have no `subDirectory` an empty string `''` must be supplied.
-
-</InlineNotification>
+To add a link to the bottom of each page that points to the current page source in GitHub, provide a `repository` object to `siteMetadata` in your `gatsby-config.js` file. You can provide a `baseUrl`, and if needed, the `subDirectory` and `branch` where your site source lives.
 
 ```js
   plugins: [

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -14,6 +14,7 @@ module.exports = themeOptions => {
     repository = {
       baseUrl: '',
       subDirectory: '',
+      branch: 'master',
     },
   } = themeOptions;
 

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -4,6 +4,12 @@ const remarkSlug = require('remark-slug');
 const defaultLunrOptions = require('./config/lunr-options');
 
 module.exports = themeOptions => {
+  const repositoryDefault = {
+    baseUrl: '',
+    subDirectory: '',
+    branch: 'master',
+  };
+
   const {
     isSearchEnabled = true,
     withWebp = false,
@@ -11,11 +17,7 @@ module.exports = themeOptions => {
     mdxExtensions = ['.mdx', '.md'],
     imageQuality = 75,
     lunrOptions = defaultLunrOptions,
-    repository = {
-      baseUrl: '',
-      subDirectory: '',
-      branch: 'master',
-    },
+    repository,
   } = themeOptions;
 
   return {
@@ -25,7 +27,7 @@ module.exports = themeOptions => {
       description:
         'Add a description by supplying it to siteMetadata in your gatsby-config.js file.',
       keywords: 'gatsby,theme,carbon,design',
-      repository,
+      repository: { ...repositoryDefault, ...repository },
     },
     plugins: [
       `gatsby-plugin-sharp`,

--- a/packages/gatsby-theme-carbon/src/components/EditLink/EditLink.js
+++ b/packages/gatsby-theme-carbon/src/components/EditLink/EditLink.js
@@ -16,15 +16,16 @@ const EditLink = ({ relativePagePath, repository: repositoryProp }) => {
           repository {
             baseUrl
             subDirectory
+            branch
           }
         }
       }
     }
   `);
 
-  const { baseUrl, subDirectory } = repositoryProp || repository;
+  const { baseUrl, subDirectory, branch } = repositoryProp || repository;
 
-  const href = `${baseUrl}/tree/master${subDirectory}/src/pages${relativePagePath}`;
+  const href = `${baseUrl}/tree/${branch}${subDirectory}/src/pages${relativePagePath}`;
 
   return baseUrl ? (
     <div className={`bx--row ${row}`}>
@@ -41,6 +42,7 @@ EditLink.propTypes = {
   repository: PropTypes.shape({
     baseUrl: PropTypes.string,
     subDirectory: PropTypes.string,
+    branch: PropTypes.string,
   }),
   relativePagePath: PropTypes.string,
 };


### PR DESCRIPTION
fixes carbon-design-system/gatsby-theme-carbon#455

Closes #455 

Adds a configuration option to specify what branch the `EditLink` should point to when opening github.

#### Changelog

**New**

- N/A

**Changed**

- config options for repository not accepts branch

**Removed**

- N/A
