### PR TITLE
fix(ImageCard): add focus border

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.2.0",
+    "eslint-config-react-app": "^5.0.2",
     "eslint-config-wesbos": "0.0.19",
     "eslint-plugin-html": "^5.0.3",
     "eslint-plugin-import": "^2.17.2",

--- a/packages/gatsby-theme-carbon/src/components/ImageCard/image-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ImageCard/image-card.scss
@@ -3,11 +3,34 @@
   padding: $spacing-05 25% $spacing-05 $spacing-05;
   position: relative;
   text-decoration: none;
+
+  &::after {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    content: '';
+    width: calc(100% - 4px);
+    height: calc(100% - 4px);
+    background: none;
+    outline: 2px solid transparent;
+    transition: outline motion(standard, productive) $duration--fast-01;
+  }
 }
 
 .#{$prefix}--image-card .#{$prefix}--tile:focus {
   outline: none;
-  //need to fix/add focus state
+
+  &::after {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    content: '';
+    width: calc(100% - 4px);
+    height: calc(100% - 4px);
+    background: none;
+    outline: 2px solid $focus;
+    transition: outline motion(standard, productive) $duration--fast-01;
+  }
 }
 
 .#{$prefix}--image-card__title {

--- a/packages/gatsby-theme-carbon/src/components/ImageCard/image-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ImageCard/image-card.scss
@@ -6,11 +6,11 @@
 
   &::after {
     position: absolute;
-    top: 2px;
-    left: 2px;
+    top: rem(2px);
+    left: rem(2px);
     content: '';
-    width: calc(100% - 4px);
-    height: calc(100% - 4px);
+    width: calc(100% - rem(4px));
+    height: calc(100% - rem(4px));
     background: none;
     outline: 2px solid transparent;
     transition: outline motion(standard, productive) $duration--fast-01;
@@ -22,11 +22,11 @@
 
   &::after {
     position: absolute;
-    top: 2px;
-    left: 2px;
+    top: rem(2px);
+    left: rem(2px);
     content: '';
-    width: calc(100% - 4px);
-    height: calc(100% - 4px);
+    width: calc(100% - rem(4px));
+    height: calc(100% - rem(4px));
     background: none;
     outline: 2px solid $focus;
     transition: outline motion(standard, productive) $duration--fast-01;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4506,7 +4506,7 @@ confusing-browser-globals@^1.0.5:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz#93ffec1f82a6e2bf2bc36769cc3a92fa20e502f3"
   integrity sha512-lI7asCibVJ6Qd3FGU7mu4sfG4try4LX3+GVS+Gv8UlrEf2AeW57piecapnog2UHZSbcX/P/1UDWVaTsblowlZg==
 
-confusing-browser-globals@^1.0.7:
+confusing-browser-globals@^1.0.7, confusing-browser-globals@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
@@ -5964,6 +5964,13 @@ eslint-config-react-app@^4.0.1:
   integrity sha512-ZsaoXUIGsK8FCi/x4lT2bZR5mMkL/Kgj+Lnw690rbvvUr/uiwgFiD8FcfAhkCycm7Xte6O5lYz4EqMx2vX7jgw==
   dependencies:
     confusing-browser-globals "^1.0.7"
+
+eslint-config-react-app@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz#df40d73a1402986030680c040bbee520db5a32a4"
+  integrity sha512-VhlESAQM83uULJ9jsvcKxx2Ab0yrmjUt8kDz5DyhTQufqWE0ssAnejlWri5LXv25xoXfdqOyeDPdfJS9dXKagQ==
+  dependencies:
+    confusing-browser-globals "^1.0.9"
 
 eslint-config-wesbos@0.0.19:
   version "0.0.19"


### PR DESCRIPTION
Closes #432 

Adds focus border to `ImageCard`

#### Changelog

**New**

- added `::after` styles to tile. 
- adds devDep `"eslint-config-react-app": "^5.0.2",` => this was because this is being hoisted in the Gatsby dependency so it's not at the top level in node_modules and my local env was breaking bc of it. Tried a couple of different ways to fix it, but with no real luck, so @joshblack and I decided this is probably the easiest fix (also in case other people run into this issue in the future).

**Reviewers**
_Note: I tried doing `outline`, `outline-offset`,  `border` and `box-shadow` as alternatives to focus the focus state but none of them were adding the styles properly. Adding the `::after` was a last resort. It seems that we do that already for `ImageCard`, so I thought it would be ok. Tile seems to be working the same when it is focused + hovered, focused + clicked._
- ensure tile is still working as expected
- ensure focus style looks correct
