### PR TITLE
When using "edit this page on github" drop the user into edit mo…

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/EditLink/EditLink.js
+++ b/packages/gatsby-theme-carbon/src/components/EditLink/EditLink.js
@@ -25,7 +25,7 @@ const EditLink = ({ relativePagePath, repository: repositoryProp }) => {
 
   const { baseUrl, subDirectory, branch } = repositoryProp || repository;
 
-  const href = `${baseUrl}/tree/${branch}${subDirectory}/src/pages${relativePagePath}`;
+  const href = `${baseUrl}/edit/${branch}${subDirectory}/src/pages${relativePagePath}`;
 
   return baseUrl ? (
     <div className={`bx--row ${row}`}>


### PR DESCRIPTION
#### Changelog

**Changed**

When  "edit this page on github" is currently selected you are taken to the github page. You have to click on the pencil icon to actually edit the file. This change skips the pencil click step.