### PR TITLE
chore(Docs): Dark Mode

### DIFF
--- a/packages/example/src/pages/components/MDX.mdx
+++ b/packages/example/src/pages/components/MDX.mdx
@@ -31,9 +31,16 @@ The most important of which is the `title`. You can also provide a description a
 ---
 title: Markdown
 description: Usage instructions for the Markdown component
+theme: dark
 keywords: 'ibm,carbon,gatsby,mdx,markdown'
 ---
 ```
+
+<InlineNotification kind="warning">
+
+Currently, dark mode is the only theme supported and is experimental. You will most likely need to do some custom stylying for selected components.
+
+</InlineNotification>
 
 ## Custom title
 

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -116,7 +116,7 @@ module.exports = {
 
 ## Global search
 
-Site-wide search is provided by the theme. The only requirement for a page to show up in the results is for it to have `title` set in the [frontmatter](/components/markdown#mdx-frontmatter).
+Site-wide search is provided by the theme. The only requirement for a page to show up in the results is for it to have `title` set in the [frontmatter](/components/MDX#frontmatter).
 To render more helpful search results (and improve SEO), you'll want to make sure your pages have `description` set in the frontmatter as well.
 
 Global search is enabled by default. To disable it, set the `isSearchEnabled` option to false.


### PR DESCRIPTION
Added documentation to turn on dark mode.

![image](https://user-images.githubusercontent.com/15822070/67586130-7f624a80-f716-11e9-9d92-b50b84087fea.png)

Also fixed a link on the configuration page.