### PR TITLE
fix: remove extra margin on inline notification

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
@@ -1,4 +1,5 @@
 .notification :global(.bx--inline-notification) {
+  margin: 0;
   max-width: 100%;
   box-shadow: none;
   margin-bottom: 0;

--- a/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
@@ -1,6 +1,8 @@
 .notification :global(.bx--inline-notification) {
   max-width: 100%;
   box-shadow: none;
+  margin-bottom: 0;
+  margin-top: 0;
   border-right: 1px solid $carbon--blue-30;
   border-top: 1px solid $carbon--blue-30;
   border-bottom: 1px solid $carbon--blue-30;


### PR DESCRIPTION
Favors universal spacing introduced by #373 

closes #453 

## Before
<img width="637" alt="Screen Shot 2019-11-02 at 2 22 45 PM" src="https://user-images.githubusercontent.com/4078018/68075916-5f690180-fd7c-11e9-91bc-ab2e934b3c51.png">


## After
<img width="622" alt="Screen Shot 2019-11-02 at 2 22 51 PM" src="https://user-images.githubusercontent.com/4078018/68075917-61cb5b80-fd7c-11e9-9033-44d56fb49c67.png">