### PR TITLE
fix: image gallery spacing

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.js
+++ b/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.js
@@ -5,6 +5,7 @@ import {
   imageButtonWrapper,
   imageTitle,
   imageInDialog,
+  figure,
 } from './ImageGalleryImage.module.scss';
 
 function ImageGalleryImage({
@@ -26,7 +27,7 @@ function ImageGalleryImage({
 
   return (
     <Column colLg={col}>
-      <figure role="group" aria-label={alt}>
+      <figure className={figure} role="group" aria-label={alt}>
         <button className={imageButtonWrapper} type="button" {...rest}>
           {children}
         </button>

--- a/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
@@ -1,3 +1,7 @@
+.figure {
+  margin-bottom: 1.5rem;
+}
+
 .image-button-wrapper {
   border: 0;
   background: none;


### PR DESCRIPTION
closes #492 

Image galleries lacked margin after the spacing re-write