### PR TITLE
fix(image-card): render as div if no href is provided

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
+++ b/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
@@ -101,6 +101,8 @@ export default class ImageCard extends React.Component {
     let isLink;
     if (href !== undefined) {
       isLink = href.charAt(0) === '/';
+    } else {
+      isLink = false;
     }
 
     const ImageCardClassNames = classnames([`${prefix}--image-card`], {
@@ -117,10 +119,9 @@ export default class ImageCard extends React.Component {
       [`${prefix}--aspect-ratio--4x3`]: aspectRatio === '4:3',
     });
 
-    const carbonTileclassNames = classnames(
-      [`${prefix}--tile`],
-      [`${prefix}--tile--clickable`]
-    );
+    const carbonTileclassNames = classnames([`${prefix}--tile`], {
+      [`${prefix}--tile--clickable`]: isLink,
+    });
 
     const titleClassNames = classnames([`${prefix}--image-card__title`], {
       [`${prefix}--image-card__title--dark`]: titleColor === 'dark',
@@ -160,7 +161,7 @@ export default class ImageCard extends React.Component {
     );
 
     let cardContainer;
-    if (disabled === true) {
+    if (disabled === true || isLink === false) {
       cardContainer = <div className={carbonTileclassNames}>{cardContent}</div>;
     } else if (isLink === true) {
       cardContainer = (

--- a/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
+++ b/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
@@ -101,8 +101,6 @@ export default class ImageCard extends React.Component {
     let isLink;
     if (href !== undefined) {
       isLink = href.charAt(0) === '/';
-    } else {
-      isLink = false;
     }
 
     const ImageCardClassNames = classnames([`${prefix}--image-card`], {
@@ -120,7 +118,7 @@ export default class ImageCard extends React.Component {
     });
 
     const carbonTileclassNames = classnames([`${prefix}--tile`], {
-      [`${prefix}--tile--clickable`]: isLink,
+      [`${prefix}--tile--clickable`]: href !== undefined,
     });
 
     const titleClassNames = classnames([`${prefix}--image-card__title`], {
@@ -161,7 +159,7 @@ export default class ImageCard extends React.Component {
     );
 
     let cardContainer;
-    if (disabled === true || isLink === false) {
+    if (disabled === true || href === undefined) {
       cardContainer = <div className={carbonTileclassNames}>{cardContent}</div>;
     } else if (isLink === true) {
       cardContainer = (


### PR DESCRIPTION
Closes #514 

Currently unless you add the `disabled` prop, an `ImageCard` will always render as an anchor.
This is problematic if you don't also provide an `href` (which is not a required prop, either).

Recently on the IBM Security design team, we've come across a situation where we want the positioning and styling of an `ImageCard` within a grid, but we don't need to link it anywhere. (So, we aren't providing an `href`). The `ImageGalleryCard` would not apply well for our designs/situation., and we also don't want to apply `disabled={true}` to `ImageCard` which would apply "do not click" cursor + icon + give an impression that the Card would be clickable under other circumstances. So we wanted to propose a fix here.

Please let me know what you think -- thanks!

#### Changelog

**Changed**

- only apply `bx--tile--clickable` class if `href === undefined` (for hover effects on links only, etc)
- render `ImageCard` as a `div` if `href === undefined`