### PR TITLE
feat(html): add default lang to site metadata, pass to helmet

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -3,7 +3,6 @@ module.exports = {
     title: 'Gatsby Theme Carbon',
     description: 'A Gatsby theme for the carbon design system',
     keywords: 'gatsby,theme,carbon',
-    lang: 'en',
   },
   pathPrefix: `/gtc`,
   plugins: [

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
     title: 'Gatsby Theme Carbon',
     description: 'A Gatsby theme for the carbon design system',
     keywords: 'gatsby,theme,carbon',
+    lang: 'en',
   },
   pathPrefix: `/gtc`,
   plugins: [

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -10,7 +10,7 @@ Gatsby themes allow you to override configuration from the theme by defining the
 </PageDescription>
 
 <AnchorLinks>
-  <AnchorLink>Site title and description</AnchorLink>
+  <AnchorLink>Site metadata</AnchorLink>
   <AnchorLink>Manifest</AnchorLink>
   <AnchorLink>Favicon</AnchorLink>
   <AnchorLink>Additional font weights</AnchorLink>
@@ -21,9 +21,11 @@ Gatsby themes allow you to override configuration from the theme by defining the
   <AnchorLink>Other options</AnchorLink>
 </AnchorLinks>
 
-## Site title and description
+## Site metadata
 
 To add a title and description to each page, simply provide them to siteMetadata in your `gatsby-config.js` file.
+
+The language attribute applied to the `<html>` tag on every page is English (`en`) by default, but you can choose to override this. For more information on declaring the language of a page in HTML, please review [W3 Criterion 3.1.1 Language of a Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page).
 
 ```js
 module.exports = {
@@ -31,6 +33,7 @@ module.exports = {
     title: 'Gatsby Theme Carbon',
     description: 'A Gatsby theme for the carbon design system',
     keywords: 'gatsby,theme,carbon',
+    lang: 'en',
   },
   plugins: ['gatsby-theme-carbon'],
 };

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -28,6 +28,7 @@ module.exports = themeOptions => {
       description:
         'Add a description by supplying it to siteMetadata in your gatsby-config.js file.',
       keywords: 'gatsby,theme,carbon,design',
+      lang: 'en',
       repository: { ...repositoryDefault, ...repository },
     },
     plugins: [

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { useMetadata } from '../util/hooks';
 
 const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
-  const { title, description, keywords } = useMetadata();
+  const { title, description, keywords, lang } = useMetadata();
 
   const getPageTitle = () => {
     switch (titleType) {
@@ -34,7 +34,9 @@ const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
           content: pageKeywords || keywords,
         },
       ]}
-    />
+    >
+      <html lang={lang || 'en'} />
+    </Helmet>
   );
 };
 

--- a/packages/gatsby-theme-carbon/src/components/Meta.js
+++ b/packages/gatsby-theme-carbon/src/components/Meta.js
@@ -35,7 +35,7 @@ const Meta = ({ pageTitle, pageDescription, pageKeywords, titleType }) => {
         },
       ]}
     >
-      <html lang={lang || 'en'} />
+      <html lang={lang} />
     </Helmet>
   );
 };

--- a/packages/gatsby-theme-carbon/src/util/hooks/useMetadata.js
+++ b/packages/gatsby-theme-carbon/src/util/hooks/useMetadata.js
@@ -9,6 +9,7 @@ const useMetadata = () => {
           description
           keywords
           isSearchEnabled
+          lang
         }
       }
     }


### PR DESCRIPTION
Closes #557

Adds default language via `lang` attribute to `HTML` element, per [Checkpoint 3.1.1.](https://www.ibm.com/able/guidelines/ci162/language_of_page.html)

#### Changelog

**New**

- add `lang` to `siteMetadata`
