### PR TITLE
feat(nav): Enable override of nav item list via shadowing

### DIFF
--- a/packages/example/src/pages/guides/navigation/sidebar.mdx
+++ b/packages/example/src/pages/guides/navigation/sidebar.mdx
@@ -33,3 +33,25 @@ Some important things to note here:
 - The `path` refer to the relative path to the mdx file in your pages
 - You can make a `Page/index.mdx` file if you'd prefer to have assets in a folder.
   The path would still just look like `/Page`
+
+## Customizing
+
+The nav item list can be customized using Gatsby theme [shadowing](../shadowing).
+Simply provide your own implementation of `src/components/LeftNav/LeftNavItemProvider.js` which can augment or replace the nav items read from `src/data/nav-items.yaml`.
+
+```javascript
+// src/gatsby-theme-carbon/components/LeftNav/LeftNavItemProvider.js
+import { useNavItems as themeUseNavItems } from 'gatsby-theme-carbon/src/components/LeftNav/LeftNavItemProvider';
+
+// add nav items
+export function useNavItems() {
+  const navItems = themeUseNavItems();
+  return navItems.concat({
+    title: 'Additional Nav Item',
+    pages: [
+      { path: '/page1', title: 'New Page 1' },
+      { path: '/page2', title: 'New Page 2' },
+    ],
+  });
+}
+```

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
@@ -1,11 +1,10 @@
 import React, { useContext } from 'react';
 import classnames from 'classnames';
-import { useStaticQuery, graphql } from 'gatsby';
-
 import {
   SideNav,
   SideNavItems,
 } from 'carbon-components-react/lib/components/UIShell';
+import { useNavItems } from './LeftNavItemProvider';
 
 import NavContext from '../../util/context/NavContext';
 import LeftNavItem from './LeftNavItem';
@@ -23,25 +22,7 @@ const LeftNav = props => {
     toggleNavState('leftNavIsOpen', 'open');
   }
 
-  const {
-    allNavItemsYaml: { edges },
-  } = useStaticQuery(graphql`
-    query LEFT_NAV_QUERY {
-      allNavItemsYaml {
-        edges {
-          node {
-            title
-            pages {
-              title
-              path
-            }
-          }
-        }
-      }
-    }
-  `);
-
-  const navItems = edges.map(({ node }) => node);
+  const navItems = useNavItems();
 
   const renderNavItems = () =>
     navItems.map((item, i) => (

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
@@ -1,10 +1,11 @@
 import React, { useContext } from 'react';
 import classnames from 'classnames';
+import { useNavItems } from './LeftNavItemProvider';
+
 import {
   SideNav,
   SideNavItems,
 } from 'carbon-components-react/lib/components/UIShell';
-import { useNavItems } from './LeftNavItemProvider';
 
 import NavContext from '../../util/context/NavContext';
 import LeftNavItem from './LeftNavItem';

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItemProvider.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItemProvider.js
@@ -1,0 +1,24 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+export function useNavItems() {
+  const {
+    allNavItemsYaml: { edges },
+  } = useStaticQuery(graphql`
+    query LEFT_NAV_QUERY {
+      allNavItemsYaml {
+        edges {
+          node {
+            title
+            pages {
+              title
+              path
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const navItems = edges.map(({ node }) => node);
+  return navItems;
+}


### PR DESCRIPTION
Refactor the Graphql query of `src/data/nav-items.yaml` to a separate file - `LeftNavItemProvider.js`.  This enables augmentation or replacement of the nav item list via Gatsby Theme shadowing.

For example, adding the following to the project will append a new nav item to the nav items gatsby-theme-carbon parsed from `/src/data/nav-items.yaml`:
```javascript
// src/gatsby-theme-carbon/components/LeftNav/LeftNavItemProvider.js
import {useNavItems as themeUseNavItems} from 'gatsby-theme-carbon/src/components/LeftNav/LeftNavItemProvider';

export function useNavItems() {
  const navItems = themeUseNavItems();
  return navItems.concat({
    title: 'Shadow Nav Item!',
    description: 'This is a nav item added via shadowing',
    pages: [
      {path: '/page1', title: 'Test Page 1'},
      {path: '/page2', title: 'Test Page 2'}
    ]
  });
}
```
The main driver for the change was to allow alternate mechanisms to populate the left nav.

#### Changelog

**New**

- Left nav items can now be customized via theme shadowing. Population of the left nav items is now in a dedicated file (`src/components/LeftNav/LeftNavItemProvider`) which can be overridden via shadowing to augment or replace the default nav item list.
