### PR TITLE
fix(resource-card): do not render empty headings if no title or…

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/ResourceCard.js
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/ResourceCard.js
@@ -102,8 +102,12 @@ export default class ResourceCard extends React.Component {
 
     const cardContent = (
       <>
-        <h5 className={`${prefix}--resource-card__subtitle`}>{subTitle}</h5>
-        <h4 className={`${prefix}--resource-card__title`}>{title}</h4>
+        {subTitle && (
+          <h5 className={`${prefix}--resource-card__subtitle`}>{subTitle}</h5>
+        )}
+        {title && (
+          <h4 className={`${prefix}--resource-card__title`}>{title}</h4>
+        )}
         <div className={`${prefix}--resource-card__icon--img`}>{children}</div>
         <div className={`${prefix}--resource-card__icon--action`}>
           {actionIcon === 'launch' && !disabled ? (


### PR DESCRIPTION
Closes #561 

When no `title` or `subtitle` prop are provided, empty heading(s) will be rendered.
Empty headings generate DAP errors for [checkpoint 2.4.6 - Headings and Labels](http://www.ibm.com/able/guidelines/ci162/headings_and_labels.html)

#### Changelog


**Changed**

- do not display title or subtitle headings if the props are not provided
