### PR TITLE
fix(container): wrap page content in main HTML5 sectioning element

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Container/Container.js
+++ b/packages/gatsby-theme-carbon/src/components/Container/Container.js
@@ -48,9 +48,9 @@ const Container = ({ children, homepage, theme }) => {
         role="presentation"
         tabIndex="-1"
       />
-      <div aria-hidden={overlayVisible} className={containerClassNames}>
+      <main aria-hidden={overlayVisible} className={containerClassNames}>
         {children}
-      </div>
+      </main>
     </>
   );
 };


### PR DESCRIPTION
Closes #563 

Currently the main content of every page is wrapped in a `div`, not an HTML5 sectioning element.
This generates DAP errors for [checkpoint 2.4.1](http://www.ibm.com/able/guidelines/ci162/bypass_blocks.html)

By wrapping the page in a `main` sectioning element, assistive tech will be able to recognize the main content of the page. This will likewise remove many DAP errors being generated per page, per orphaned element (for example, removes approximately 9 errors on the demo site homepage).

#### Changelog


**Changed**

- update `Container` component to wrap page content in `main` HTML5 sectioning element