### PR TITLE
fix(aside): add spread prop, update docs with accessibility labe…

### DIFF
--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -11,6 +11,12 @@ It should only be used within a `<Column>` component with specific parameters. `
 
 </PageDescription>
 
+<InlineNotification kind="warning">
+
+**Warning:** If you use multiple `Aside` components on a single page, you need to provide an accessibility label so that someone using assistive technology can quickly understand the purpose of the landmark. See [Mozilla Developer Network's documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role#Labeling_landmarks) for more information. Props for accessibility labels are described in the [Props section](#props) below.
+
+</InlineNotification>
+
 ## Example
 
 <Row>

--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -57,9 +57,9 @@ What we borrow from our own design history is not a mid-century aesthetic in sty
 
 ### Props
 
-| property       | propType | required | default | description                                                                                                                       |
-| -------------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| property        | propType | required | default | description                                                                                                                       |
+| --------------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | aria-label      | string   |          |         | Specify an `aria-label` value to provide a label to the inner aside element.                                                      |
 | aria-labelledBy | string   |          |         | Specify an `aria-labelledby` value that references the id of an existing element to serve as a label for the inner aside element. |
-| children       | node     |          |         |                                                                                                                                   |
-| className      | string   |          |         | Add custom class name                                                                                                             |
+| children        | node     |          |         |                                                                                                                                   |
+| className       | string   |          |         | Add custom class name                                                                                                             |

--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -32,7 +32,7 @@ Aesthetic is defined as the philosophical theory or set of principles governing 
 
 </Column>
 <Column colMd={2} colLg={3} offsetMd={1} offsetLg={1}>
-<Aside ariaLabel="Example aside">
+<Aside aria-label="Example aside">
 
 **Good design is always good design.**
 
@@ -59,7 +59,7 @@ What we borrow from our own design history is not a mid-century aesthetic in sty
 
 | property       | propType | required | default | description                                                                                                                       |
 | -------------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| ariaLabel      | string   |          |         | Specify an `aria-label` value to provide a label to the inner aside element.                                                      |
-| ariaLabelledBy | string   |          |         | Specify an `aria-labelledby` value that references the id of an existing element to serve as a label for the inner aside element. |
+| aria-label      | string   |          |         | Specify an `aria-label` value to provide a label to the inner aside element.                                                      |
+| aria-labelledBy | string   |          |         | Specify an `aria-labelledby` value that references the id of an existing element to serve as a label for the inner aside element. |
 | children       | node     |          |         |                                                                                                                                   |
 | className      | string   |          |         | Add custom class name                                                                                                             |

--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -51,7 +51,9 @@ What we borrow from our own design history is not a mid-century aesthetic in sty
 
 ### Props
 
-| property  | propType | required | default | description           |
-| --------- | -------- | -------- | ------- | --------------------- |
-| children  | node     |          |         |                       |
-| className | string   |          |         | Add custom class name |
+| property       | propType | required | default | description                                                                                                                       |
+| -------------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| ariaLabel      | string   |          |         | Specify an `aria-label` value to provide a label to the inner aside element.                                                      |
+| ariaLabelledBy | string   |          |         | Specify an `aria-labelledby` value that references the id of an existing element to serve as a label for the inner aside element. |
+| children       | node     |          |         |                                                                                                                                   |
+| className      | string   |          |         | Add custom class name                                                                                                             |

--- a/packages/example/src/pages/components/Aside.mdx
+++ b/packages/example/src/pages/components/Aside.mdx
@@ -13,7 +13,7 @@ It should only be used within a `<Column>` component with specific parameters. `
 
 <InlineNotification kind="warning">
 
-**Warning:** If you use multiple `Aside` components on a single page, you need to provide an accessibility label so that someone using assistive technology can quickly understand the purpose of the landmark. See [Mozilla Developer Network's documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role#Labeling_landmarks) for more information. Props for accessibility labels are described in the [Props section](#props) below.
+**Warning:** If you use more than one `<Aside>` component on a single page, you need to provide an accessibility label so that someone using assistive technology can quickly understand the purpose of the landmark. See [Mozilla Developer Network's documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role#Labeling_landmarks) for more information. Props for accessibility labels are described in the [Props section](#props) below.
 
 </InlineNotification>
 
@@ -32,7 +32,7 @@ Aesthetic is defined as the philosophical theory or set of principles governing 
 
 </Column>
 <Column colMd={2} colLg={3} offsetMd={1} offsetLg={1}>
-<Aside>
+<Aside ariaLabel="Example aside">
 
 **Good design is always good design.**
 

--- a/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
+++ b/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
@@ -25,7 +25,13 @@ export default class Aside extends React.Component {
   };
 
   render() {
-    const { ariaLabel, ariaLabelledBy, children, className } = this.props;
+    const {
+      ariaLabel,
+      ariaLabelledBy,
+      children,
+      className,
+      ...rest
+    } = this.props;
 
     const captionClasses = classnames(aside, {
       [className]: className,
@@ -36,14 +42,10 @@ export default class Aside extends React.Component {
       'aria-labelledby': ariaLabelledBy,
     };
 
-    if (ariaLabel || ariaLabelledBy) {
-      return (
-        <aside className={captionClasses} {...accessibilityLabel}>
-          {children}
-        </aside>
-      );
-    }
-
-    return <div className={captionClasses}>{children}</div>;
+    return (
+      <aside className={captionClasses} {...accessibilityLabel} {...rest}>
+        {children}
+      </aside>
+    );
   }
 }

--- a/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
+++ b/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
@@ -11,39 +11,17 @@ export default class Aside extends React.Component {
      * Specify a custom class
      */
     className: PropTypes.string,
-
-    /**
-     * Specify an `aria-label` value to provide a label to the inner aside element.
-     */
-    ariaLabel: PropTypes.string,
-
-    /**
-     * Specify an `aria-labelledby` value that references the id of an existing
-     * element to serve as a label for the inner aside element.
-     */
-    ariaLabelledBy: PropTypes.string,
   };
 
   render() {
-    const {
-      ariaLabel,
-      ariaLabelledBy,
-      children,
-      className,
-      ...rest
-    } = this.props;
+    const { children, className, ...rest } = this.props;
 
     const captionClasses = classnames(aside, {
       [className]: className,
     });
 
-    const accessibilityLabel = {
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-    };
-
     return (
-      <aside className={captionClasses} {...accessibilityLabel} {...rest}>
+      <aside className={captionClasses} {...rest}>
         {children}
       </aside>
     );

--- a/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
+++ b/packages/gatsby-theme-carbon/src/components/Aside/Aside.js
@@ -11,15 +11,39 @@ export default class Aside extends React.Component {
      * Specify a custom class
      */
     className: PropTypes.string,
+
+    /**
+     * Specify an `aria-label` value to provide a label to the inner aside element.
+     */
+    ariaLabel: PropTypes.string,
+
+    /**
+     * Specify an `aria-labelledby` value that references the id of an existing
+     * element to serve as a label for the inner aside element.
+     */
+    ariaLabelledBy: PropTypes.string,
   };
 
   render() {
-    const { children, className } = this.props;
+    const { ariaLabel, ariaLabelledBy, children, className } = this.props;
 
     const captionClasses = classnames(aside, {
       [className]: className,
     });
 
-    return <aside className={captionClasses}>{children}</aside>;
+    const accessibilityLabel = {
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+    };
+
+    if (ariaLabel || ariaLabelledBy) {
+      return (
+        <aside className={captionClasses} {...accessibilityLabel}>
+          {children}
+        </aside>
+      );
+    }
+
+    return <div className={captionClasses}>{children}</div>;
   }
 }

--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -161,3 +161,8 @@ img {
   max-width: 100%;
   flex: auto;
 }
+
+// TODO: remove when fix is released. See https://github.com/carbon-design-system/carbon/issues/4804
+.bx--inline-notification--low-contrast:before {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
Closes #566 

Currently the `Aside` component renders an `<aside>` element that is missing required accessibility labels. This `<aside>` element needs either an `aria-label` attribute (to provide a label) or `aria-labelledby` attribute (to use an existing element, like a heading, as a label) per [Checkpoint 2.4.1](https://www.ibm.com/able/guidelines/ci162/bypass_blocks.html)

This PR ~proposes adding `ariaLabel` and `ariaLabelledBy` props so that users can provide either of these required accessibility labels, depending on their context/situation~ updates examples and documentation to include `aria-label` and `aria-labelledBy`

~If one of these accessibility labels are NOT provided, then the `Aside` component will render a `<div>` element inside of an `<aside>`.~

#### Changelog

**New**

- add `ariaLabel` and `ariaLabelledBy` props with documentation

**Changed**

- update docs
- add temporary style override to fix https://github.com/carbon-design-system/carbon/issues/4804