### PR TITLE
fix(skip-to-content): make link text white to meet AA contrast

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -42,6 +42,10 @@ header.header {
   font-weight: 600;
 }
 
+.header .skip-to-content {
+  color: $carbon--white-0;
+}
+
 .header .skip-to-content:focus {
   border: 2px solid $carbon--white-0;
   margin: 0;


### PR DESCRIPTION
Closes #570 

#### Changelog

**Changed**

- make the `SkipToContent` link text white so that it makes AA minimum contrast requirements