### PR TITLE
fix(code-blocks): add alt value to svg inside anchors

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Code/PathRow.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/PathRow.js
@@ -22,7 +22,7 @@ const PathRow = ({ src, path, children }) => {
           href={src}
           style={{ position: 'relative', zIndex: 200 }}
         >
-          <Launch16 />
+          <Launch16 alt="View source" />
         </a>
       ) : (
         <CopyButton

--- a/packages/gatsby-theme-carbon/src/components/Code/Sidebar.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Sidebar.js
@@ -32,7 +32,7 @@ const Sidebar = ({ src, path, children }) => {
           href={src}
           style={{ zIndex: 200 }}
         >
-          <Launch16 />
+          <Launch16 alt="View source" />
         </a>
       )}
     </div>


### PR DESCRIPTION
Closes #572 

Adds `alt` attribute to svg elements inside anchors used in the `CodeBlock` component (see #572 for context)

#### Changelog

**Changed**

- add `alt` attribute to svgs