### PR TITLE
fix: increase max-height of switcher

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
@@ -36,7 +36,7 @@
     // https://css-tricks.com/using-css-transitions-auto-dimensions/
     // Tied to the height of the app switcher. Allows for animating up to auto.
     // Matching the height exactly is imperitive to keep the correct animation timing.
-    max-height: 492px;
+    max-height: 508px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5); // header__menu shadow
   }
 }

--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.module.scss
@@ -36,7 +36,7 @@
     // https://css-tricks.com/using-css-transitions-auto-dimensions/
     // Tied to the height of the app switcher. Allows for animating up to auto.
     // Matching the height exactly is imperitive to keep the correct animation timing.
-    max-height: 458px;
+    max-height: 492px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5); // header__menu shadow
   }
 }


### PR DESCRIPTION
Closes #579

Increases max-height of switcher so that bottom link isn't cut off.

### Review
- make sure all links are visible in switcher on desktop
- @jeanservaas make sure spacing below bottom link is correct, not 100% sure what it should be


