### PR TITLE
fix: update right spacing for paragraphs and lists

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
@@ -4,30 +4,22 @@
 
 .paragraph {
   @include carbon--type-style('body-long-02');
+  padding-left: $spacing-05;
+  padding-right: $spacing-05;
 
   @include carbon--breakpoint('md') {
-    padding-right: $spacing-05;
-  }
-
-  @include carbon--breakpoint-down('sm') {
-    padding-right: $spacing-05;
+    padding-right: $spacing-07;
   }
 }
 
 // Responsive by default
 .paragraph--responsive {
-  padding-left: $spacing-05;
-
-  @include carbon--breakpoint-down('sm') {
-    padding-right: $spacing-05;
-  }
-
   // 8 col
   @include carbon--breakpoint('md') {
     width: 75%;
   }
 
-  // 16 col
+  // 8 col
   @include carbon--breakpoint('lg') {
     width: 66.667%;
   }
@@ -55,6 +47,11 @@
 .h6,
 .list {
   width: 100%;
+  padding-right: $spacing-05;
+
+  @include carbon--breakpoint('md') {
+    padding-right: $spacing-07;
+  }
 
   @include carbon--breakpoint('lg') {
     width: 66.667%;


### PR DESCRIPTION
Closes #582
Closes #503 
Closes #470 

#### Changelog

**Changed**

- Updated paragraph and list spacing, 16px to the right at mobile, 32px at tablet and above