### PR TITLE
fix: remove container classname scope

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Container/Container.js
+++ b/packages/gatsby-theme-carbon/src/components/Container/Container.js
@@ -34,7 +34,7 @@ const Container = ({ children, homepage, theme }) => {
   })();
 
   const containerClassNames = classnames({
-    container: theme !== 'dark',
+    container: true,
     'container--homepage': homepage,
     'container--dark': theme === 'dark',
   });

--- a/packages/gatsby-theme-carbon/src/components/Container/Container.js
+++ b/packages/gatsby-theme-carbon/src/components/Container/Container.js
@@ -34,7 +34,7 @@ const Container = ({ children, homepage, theme }) => {
   })();
 
   const containerClassNames = classnames({
-    container: theme !== 'dark' || !homepage,
+    container: theme !== 'dark',
     'container--homepage': homepage,
     'container--dark': theme === 'dark',
   });

--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -8,7 +8,7 @@
   margin-top: rem(48px);
 }
 
-.#{$prefix}--grid {
+.container .#{$prefix}--grid {
   margin: 0;
 
   @include carbon--breakpoint('lg') {
@@ -24,7 +24,7 @@
   }
 }
 
-.#{$prefix}--col-no-gutter {
+.container .#{$prefix}--col-no-gutter {
   padding: 0;
 }
 
@@ -115,48 +115,48 @@ img {
 // Grid style updates/overrides, moved over from deprecated addons pacakge
 
 // No gutter class names
-.#{$prefix}--no-gutter-lg {
+.container .#{$prefix}--no-gutter-lg {
   @include carbon--breakpoint('lg') {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.#{$prefix}--no-gutter-md {
+.container .#{$prefix}--no-gutter-md {
   @include carbon--breakpoint('md') {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.#{$prefix}--no-gutter-sm {
+.container .#{$prefix}--no-gutter-sm {
   padding-left: 0;
   padding-right: 0;
 }
 
-.#{$prefix}--no-gutter-lg--left {
+.container .#{$prefix}--no-gutter-lg--left {
   @include carbon--breakpoint('lg') {
     padding-left: 0;
   }
 }
 
-.#{$prefix}--no-gutter-md--left {
+.container .#{$prefix}--no-gutter-md--left {
   @include carbon--breakpoint('md') {
     padding-left: 0;
   }
 }
 
-.#{$prefix}--no-gutter-sm--left {
+.container .#{$prefix}--no-gutter-sm--left {
   padding-left: 0;
 }
 
 // Clears styles for nested grid components
-.#{$prefix}--row .#{$prefix}--row {
+.container .#{$prefix}--row .#{$prefix}--row {
   margin-left: 0;
   margin-right: 0;
 }
 
-.#{$prefix}--row .#{$prefix}--row > div {
+.container .#{$prefix}--row .#{$prefix}--row > div {
   margin: 0;
   max-width: 100%;
   flex: auto;

--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -8,7 +8,7 @@
   margin-top: rem(48px);
 }
 
-.container .#{$prefix}--grid {
+.#{$prefix}--grid {
   margin: 0;
 
   @include carbon--breakpoint('lg') {
@@ -24,7 +24,7 @@
   }
 }
 
-.container .#{$prefix}--col-no-gutter {
+.#{$prefix}--col-no-gutter {
   padding: 0;
 }
 
@@ -115,48 +115,48 @@ img {
 // Grid style updates/overrides, moved over from deprecated addons pacakge
 
 // No gutter class names
-.container .#{$prefix}--no-gutter-lg {
+.#{$prefix}--no-gutter-lg {
   @include carbon--breakpoint('lg') {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.container .#{$prefix}--no-gutter-md {
+.#{$prefix}--no-gutter-md {
   @include carbon--breakpoint('md') {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.container .#{$prefix}--no-gutter-sm {
+.#{$prefix}--no-gutter-sm {
   padding-left: 0;
   padding-right: 0;
 }
 
-.container .#{$prefix}--no-gutter-lg--left {
+.#{$prefix}--no-gutter-lg--left {
   @include carbon--breakpoint('lg') {
     padding-left: 0;
   }
 }
 
-.container .#{$prefix}--no-gutter-md--left {
+.#{$prefix}--no-gutter-md--left {
   @include carbon--breakpoint('md') {
     padding-left: 0;
   }
 }
 
-.container .#{$prefix}--no-gutter-sm--left {
+.#{$prefix}--no-gutter-sm--left {
   padding-left: 0;
 }
 
 // Clears styles for nested grid components
-.container .#{$prefix}--row .#{$prefix}--row {
+.#{$prefix}--row .#{$prefix}--row {
   margin-left: 0;
   margin-right: 0;
 }
 
-.container .#{$prefix}--row .#{$prefix}--row > div {
+.#{$prefix}--row .#{$prefix}--row > div {
   margin: 0;
   max-width: 100%;
   flex: auto;


### PR DESCRIPTION
closes #578 

Fix for Carbon homepage, no-gutter classes aren't being applied because the homepage doesn't use the .container class. This should also fix the max breakpoint feature card mis-alignment

#### Changelog

Added the container class back to the homepage template

### Testing

Ensure that this won't break anything - check components using the grid, and the aside component which has nested grid classnames.
