### PR TITLE
fix(image-card): allow additional props

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
+++ b/packages/gatsby-theme-carbon/src/components/ImageCard/ImageCard.js
@@ -96,6 +96,7 @@ export default class ImageCard extends React.Component {
       aspectRatio,
       actionIcon,
       className,
+      ...rest
     } = this.props;
 
     let isLink;
@@ -181,7 +182,7 @@ export default class ImageCard extends React.Component {
     }
 
     return (
-      <div className={ImageCardClassNames}>
+      <div className={ImageCardClassNames} {...rest}>
         <div className={aspectRatioClassNames}>
           <div className={`${prefix}--aspect-ratio--object`}>
             {cardContainer}


### PR DESCRIPTION
Currently we cannot pass a `style` attribute to the `ImageCard` component because it doesn't allow additional props. This PR proposes adding `...rest` to allow that 👍 

#### Changelog

**New**

- add spread operator to pass through additional props
