### PR TITLE
fix(left-nav): add support for nested URLs

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItem.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavItem.js
@@ -71,7 +71,7 @@ const SubNavItems = ({ items, pathname, onClick }) =>
   items.map((item, i) => {
     const hasActiveTab =
       item.path.split('/').filter(Boolean).length > 2
-        ? pathname.includes(item.path.slice(0, item.path.lastIndexOf('/')))
+        ? item.path === pathname
         : pathname.split('/').toString() === item.path.split('/').toString();
     return (
       <SideNavMenuItem


### PR DESCRIPTION
Currently, the theme doesn't support active navigation item links for URLs with a nested structure - this PR aims to address that.

I don't fully understand the intent behind the original line so perhaps this can be a discussion in order to ensure all cases are covered.

## Expected

<img width="735" alt="Expected" src="https://user-images.githubusercontent.com/3846874/70553545-37d33900-1b73-11ea-8f4a-b1ccf045a083.png">

## Actual

<img width="633" alt="Actual" src="https://user-images.githubusercontent.com/3846874/70553524-30139480-1b73-11ea-83c4-1e1ea8537291.png">

#### Changelog

**Changed**

Check the navigation item link path directly against `pathname`