### PR TITLE
fix(autolink-headers): set opacity to 1 when links are focussed

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/AutolinkHeader/AutolinkHeader.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/AutolinkHeader/AutolinkHeader.module.scss
@@ -10,7 +10,8 @@
   top: 0;
 
   &:hover,
-  &:active {
+  &:active,
+  &:focus {
     opacity: 1;
   }
 


### PR DESCRIPTION
Closes #601 

Let me know if you want any additional `:focus` state styles. At a minimum to fix #601, I just fixed the `opacity` issue. 👍 

#### Changelog

**Changed**

- set `opacity: 1` when header link has `:focus` state