### PR TITLE
fix(skip-to-content): add explicit href to component, add id to…

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Container/Container.js
+++ b/packages/gatsby-theme-carbon/src/components/Container/Container.js
@@ -48,7 +48,11 @@ const Container = ({ children, homepage, theme }) => {
         role="presentation"
         tabIndex="-1"
       />
-      <main aria-hidden={overlayVisible} className={containerClassNames}>
+      <main
+        id="main-content"
+        aria-hidden={overlayVisible}
+        className={containerClassNames}
+      >
         {children}
       </main>
     </>

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.js
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.js
@@ -36,7 +36,7 @@ const Header = ({ children }) => {
   return (
     <>
       <ShellHeader aria-label="Header" className={header}>
-        <SkipToContent className={skipToContent} />
+        <SkipToContent href="#main-content" className={skipToContent} />
         <HeaderMenuButton
           className={cx('bx--header__action--menu', headerButton)}
           aria-label="Open menu"


### PR DESCRIPTION
Closes #606

The `SkipToContent` component needs to target part of the page so that keyboard users can jump to it, so I suggest adding `id="main-content"` to the `<main>` element of each page. NOTE: this would *not* include homepage, since it doesn't appear to have a `SkipToContent` link -- is that acceptable?

Also, since the default `href` for the `SkipToContent` is `#main-content`, I suggest explicitly defining it where the component is used so that folks who come along later can quickly see where the link goes. 👍 

#### Changelog

**New**

- add `href="#main-content"` to the `SkipToContent` component
- add `id="main-content"` to the `<main>` element on each (non-homepage) page.
