### PR TITLE
fix: put anchor link columns on grid 

### DIFF
--- a/packages/example/src/pages/components/AnchorLinks.mdx
+++ b/packages/example/src/pages/components/AnchorLinks.mdx
@@ -19,6 +19,10 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
   <AnchorLink>Link 1</AnchorLink>
   <AnchorLink>Link 2</AnchorLink>
   <AnchorLink>Link 3</AnchorLink>
+  <AnchorLink>Link 4</AnchorLink>
+  <AnchorLink>Link 5</AnchorLink>
+  <AnchorLink>Link 6</AnchorLink>
+  <AnchorLink>Link 7</AnchorLink>
 </AnchorLinks>
 
 #### Small
@@ -38,6 +42,10 @@ For most pages, we recommend starting with a `PageDescription` followed by `Anch
   <AnchorLink>Link 1</AnchorLink>
   <AnchorLink>Link 2</AnchorLink>
   <AnchorLink>Link 3</AnchorLink>
+  <AnchorLink>Link 4</AnchorLink>
+  <AnchorLink>Link 5</AnchorLink>
+  <AnchorLink>Link 6</AnchorLink>
+  <AnchorLink>Link 7</AnchorLink>
 </AnchorLinks>
 ```
 

--- a/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLinks.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/AnchorLinks/AnchorLinks.module.scss
@@ -1,11 +1,8 @@
 .list {
   width: 100%;
-  @include carbon--breakpoint('md') {
-    width: 75%;
-  }
 
   @include carbon--breakpoint('lg') {
-    width: 58.33%;
+    width: 66.67%;
   }
 }
 


### PR DESCRIPTION
closes #586

Anchor link width now matches up to 8 columns width (4 columns each when split into two)
Updated the example to have more items to show the 2 column layout
