### PR TITLE
fix: ignore rule exceptions

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
@@ -1,3 +1,7 @@
+// Gatsby doesn't include the recommended exceptions to this rule
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
+
 import React, { useEffect, createContext, useContext } from 'react';
 import { Link } from 'gatsby';
 import cx from 'classnames';
@@ -42,26 +46,24 @@ const Menu = ({ results, onKeyDown }) => {
   });
 
   return (
-    <>
-      <ul
-        aria-labelledby="search-label"
-        role="menu"
-        id="search-menu"
-        className={cx(list, {
-          [hidden]: results.length === 0,
-        })}
-      >
-        {resultsWithTabAdded.map((page, index) => (
-          <MenuItem
-            id={`menu-item-${index}`}
-            onKeyDown={onKeyDown}
-            key={page.path}
-            index={index}
-            page={page}
-          />
-        ))}
-      </ul>
-    </>
+    <ul
+      aria-labelledby="search-label"
+      role="menu"
+      id="search-menu"
+      className={cx(list, {
+        [hidden]: results.length === 0,
+      })}
+    >
+      {resultsWithTabAdded.map((page, index) => (
+        <MenuItem
+          id={`menu-item-${index}`}
+          onKeyDown={onKeyDown}
+          key={page.path}
+          index={index}
+          page={page}
+        />
+      ))}
+    </ul>
   );
 };
 

--- a/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.js
@@ -1,3 +1,7 @@
+// Gatsby doesn't include the recommended exceptions to this rule
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
+
 import React, {
   useContext,
   createContext,


### PR DESCRIPTION
Closes #649 

Gatsby recently turned on `eslint-plugiun-jsx-a11y` for Gatsby projects (https://github.com/gatsbyjs/gatsby/pull/19946) this means that the issues will show up in the dev console. This is awesome but some of their config is overzealous.

In particular, it fails to include the recommended exceptions to the [no-noninteractive-element-to-interactive-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details).


The two failures we see in the error message would be ignored with this rule. Both of the w3 examples used to build this component would fail this check: 

1. [Menu](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html)

2. [Tabs](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html)
