### PR TITLE
fix(homepage): use blue40 for links on dark homepage container

### DIFF
--- a/packages/example/src/pages/index.mdx
+++ b/packages/example/src/pages/index.mdx
@@ -5,7 +5,7 @@ export default HomepageTemplate;
 
 <PageDescription>
 
-The homepage content here lives in the `src/pages/index.mdx` directory at the root of your project. Just like the other mdx pages, you can use all of our theme components here without importing them.
+The homepage content here lives in the `src/pages/index.mdx` directory at the root of your project. Just like the other mdx pages, you can use all of our theme components here without importing them. Review the [MDX example source](https://github.com/carbon-design-system/gatsby-theme-carbon/blob/master/packages/example/src/pages/index.mdx).
 
 </PageDescription>
 

--- a/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
+++ b/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
@@ -8,17 +8,11 @@
 .container--dark a.#{$prefix}--link:hover,
 .container--dark a.#{$prefix}--link:active,
 .container--dark a.#{$prefix}--link:active:visited,
-.container--dark a.#{$prefix}--link:active:visited:hover,
-.container--homepage a.#{$prefix}--link,
-.container--homepage a.#{$prefix}--link:hover,
-.container--homepage a.#{$prefix}--link:active,
-.container--homepage a.#{$prefix}--link:active:visited,
-.container--homepage a.#{$prefix}--link:active:visited:hover {
+.container--dark a.#{$prefix}--link:active:visited:hover {
   color: $carbon--blue-40;
 }
 
-.container--dark a:focus,
-.container--homepage a:focus {
+.container--dark a:focus {
   outline-color: $carbon--blue-40;
 }
 

--- a/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
+++ b/packages/gatsby-theme-carbon/src/components/Homepage/homepage.scss
@@ -4,9 +4,22 @@
   color: $carbon--white-0;
 }
 
-.container--dark a,
-.container--homepage a {
+.container--dark a.#{$prefix}--link,
+.container--dark a.#{$prefix}--link:hover,
+.container--dark a.#{$prefix}--link:active,
+.container--dark a.#{$prefix}--link:active:visited,
+.container--dark a.#{$prefix}--link:active:visited:hover,
+.container--homepage a.#{$prefix}--link,
+.container--homepage a.#{$prefix}--link:hover,
+.container--homepage a.#{$prefix}--link:active,
+.container--homepage a.#{$prefix}--link:active:visited,
+.container--homepage a.#{$prefix}--link:active:visited:hover {
   color: $carbon--blue-40;
+}
+
+.container--dark a:focus,
+.container--homepage a:focus {
+  outline-color: $carbon--blue-40;
 }
 
 // Homepage image header area


### PR DESCRIPTION
Resolves https://github.com/carbon-design-system/carbon-website/issues/792
Resolves https://github.com/carbon-design-system/carbon-website/issues/536

The links on the dark container of the homepage are not styled for `:hover`, `:active`, `:active:visited`, or `:active:visited:hover` states. As a result, these states show default `bx--link` colors which are not accessible against the dark background. (The also applied to the focus outline).

#### Changelog

**New**

- add example link outside of homepage callout so that the modified link styles can be easily tested.

**Changed**

- add style overrides for links on the dark container background of the homepage.