### PR TITLE
remove sub-title in feature card demo

### DIFF
--- a/packages/example/src/pages/components/FeatureCard.mdx
+++ b/packages/example/src/pages/components/FeatureCard.mdx
@@ -24,7 +24,6 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
 </FeatureCard>
 
 <FeatureCard
-  subTitle="With subtitle"
   title="Title"
   actionIcon="arrowRight"
   href="/"


### PR DESCRIPTION
Closes #667 

remove sub title in the second feature card 