### PR TITLE
fix(inlineNotification): remove extra border and update width at tablet breakpoint

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.js
+++ b/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.js
@@ -20,13 +20,13 @@ export default class InlineNotification extends React.Component {
   render() {
     const { children, className, kind } = this.props;
 
-    const notifcationClasses = classnames(notification, {
+    const notificationClasses = classnames(notification, {
       [className]: className,
     });
 
     return (
       <Row>
-        <Column colLg={8} className={notifcationClasses}>
+        <Column colLg={8} colMd={6} className={notificationClasses}>
           <CarbonInlineNotification
             lowContrast
             hideCloseButton

--- a/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/InlineNotification/InlineNotification.module.scss
@@ -4,27 +4,6 @@
   box-shadow: none;
   margin-bottom: 0;
   margin-top: 0;
-  border-right: 1px solid $carbon--blue-30;
-  border-top: 1px solid $carbon--blue-30;
-  border-bottom: 1px solid $carbon--blue-30;
-}
-
-.notification :global(.bx--inline-notification--error) {
-  border-top-color: $carbon--red-30;
-  border-bottom-color: $carbon--red-30;
-  border-right-color: $carbon--red-30;
-}
-
-.notification :global(.bx--inline-notification--success) {
-  border-top-color: $carbon--green-30;
-  border-bottom-color: $carbon--green-30;
-  border-right-color: $carbon--green-30;
-}
-
-.notification :global(.bx--inline-notification--warning) {
-  border-top-color: $inverse-support-03;
-  border-bottom-color: $inverse-support-03;
-  border-right-color: $inverse-support-03;
 }
 
 .notification :global(.bx--inline-notification__subtitle p) {


### PR DESCRIPTION
Closes #718

Removes double border, updates width at tablet breakpoint to be 6 cols to match text width.

#### Testing

Test that `InlineNotification` styles look correct at all breakpoints
