### PR TITLE
fix: remove extra space beneath do-dont-captions

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontExample/do-dont-example.scss
@@ -134,7 +134,6 @@
   @include carbon--type-style('body-short-01');
   margin: 0;
   padding: 0;
-  padding-bottom: $spacing-06;
 }
 
 .#{$prefix}--col-lg-4 .#{$prefix}--example__caption {

--- a/packages/gatsby-theme-carbon/src/components/DoDontRow/DoDontRow.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/DoDontRow/DoDontRow.module.scss
@@ -47,7 +47,6 @@
   @include carbon--type-style('body-short-01');
   margin: 0;
   padding: 0;
-  padding-bottom: $spacing-06;
 }
 
 [class*='--col'] .caption {


### PR DESCRIPTION
Closes #768 