### PR TITLE
chore(release): update carbon to v10.11.0-rc.1

### DIFF
--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -14,8 +14,8 @@
     "react-dom": "^16.13.1"
   },
   "dependencies": {
-    "@carbon/elements": "^10.11.0-rc.0",
-    "@carbon/icons-react": "^10.10.0-rc.0",
+    "@carbon/elements": "^10.11.0-rc.1",
+    "@carbon/icons-react": "^10.10.0-rc.1",
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",
     "@mdx-js/mdx": "^1.5.5",
@@ -23,8 +23,8 @@
     "@reach/router": "^1.2.1",
     "@vimeo/player": "^2.9.1",
     "beautiful-react-hooks": "^0.23.1",
-    "carbon-components": "^10.11.0-rc.0",
-    "carbon-components-react": "^7.11.0-rc.0",
+    "carbon-components": "^10.11.0-rc.1",
+    "carbon-components-react": "^7.11.0-rc.1",
     "carbon-icons": "^7.0.7",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,77 +1005,77 @@
   resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.9.0-rc.0.tgz#a11614a2307e1efb61ec9b2616f6f5176eeea1b5"
   integrity sha512-9SjiA6nYfTV3dQJwvQ0O3mwo6QRMbFkaUvx605AvssTjN7/PPZPKLb3uDPYHkMfCb3ipEou6Eu6nS3feFL5Ltw==
 
-"@carbon/elements@^10.11.0-rc.0":
-  version "10.11.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/elements/-/elements-10.11.0-rc.0.tgz#fd29859d16471dca3531690ef85c2c4ad1b23e77"
-  integrity sha512-lvqF0rQAXQmVlRtvrB52Mbkan8ooa42BblXkeVDoWxnyhjImUnSViP8c9Hifsfo18+SE4Oo/DNSe0RKUF7aRxg==
+"@carbon/elements@^10.11.0-rc.1":
+  version "10.11.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/elements/-/elements-10.11.0-rc.1.tgz#1d96641eff563ed0c8af633b7b9baa0ef3e8f9a4"
+  integrity sha512-6v3a5qmKWBl19luR1ao4ehtoA8LGy2+1fo3s6x/3G4zBTMPMZN92G2I/sL8sjqmpOZ1kk//o0Zfm4x5ylZQKAg==
   dependencies:
     "@carbon/colors" "^10.9.0-rc.0"
-    "@carbon/grid" "^10.10.0-rc.0"
-    "@carbon/icons" "^10.10.0-rc.0"
+    "@carbon/grid" "^10.10.0-rc.1"
+    "@carbon/icons" "^10.10.0-rc.1"
     "@carbon/import-once" "^10.3.0"
-    "@carbon/layout" "^10.9.0-rc.0"
+    "@carbon/layout" "^10.9.0-rc.1"
     "@carbon/motion" "^10.7.0-rc.0"
-    "@carbon/themes" "^10.11.0-rc.0"
-    "@carbon/type" "^10.10.0-rc.0"
+    "@carbon/themes" "^10.11.0-rc.1"
+    "@carbon/type" "^10.10.0-rc.1"
 
-"@carbon/grid@^10.10.0-rc.0":
-  version "10.10.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-10.10.0-rc.0.tgz#9124345212e2ae3a0ae206905fe8a2706f439d78"
-  integrity sha512-OdmfTLaiizEK4lpRBPu6DawCK8ZAcsPpWQZrfoAffD+pM8SOafe+llAAoWfmQQXq8y7tyWM/rKW4N3I5Jbzz4w==
+"@carbon/grid@^10.10.0-rc.1":
+  version "10.10.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-10.10.0-rc.1.tgz#10803585ea9a411da8e131f8b34cbcd8345b6c85"
+  integrity sha512-GUoTrICXl5KMwQ1I3JSX8F394+Un/zT4bg9/ovHT+xT2nAeNue+Hat6HCGOlQEKuMso1EQ4ZtmXraGye1/sLyA==
   dependencies:
     "@carbon/import-once" "^10.3.0"
-    "@carbon/layout" "^10.9.0-rc.0"
+    "@carbon/layout" "^10.9.0-rc.1"
 
 "@carbon/icon-helpers@^10.7.0-rc.0":
   version "10.7.0-rc.0"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.7.0-rc.0.tgz#07bc2103364cbfe687fafba402402aa555243792"
   integrity sha512-sHFi/fTbRhN/D5Kwx7FYCAGB0vTnvSKKs6xSeiGafJqs4ekqMswLT/QBOZIQ0RQWDAOd79Ys1vcEHZ/fRM381g==
 
-"@carbon/icons-react@^10.10.0-rc.0":
-  version "10.10.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-10.10.0-rc.0.tgz#fc1f61dceb29b154cc745527e2c04296b0d61d71"
-  integrity sha512-ojeUKGVkyZWZHlvfAW7nGgUqmH+3aW/M09c5IC5xg/qzxyUkbqMda7LFqhppvbJbV7podyAY8jsJe/+N+x4y+A==
+"@carbon/icons-react@^10.10.0-rc.1":
+  version "10.10.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-10.10.0-rc.1.tgz#d265cb8379a6b090114a3929ce1d33fc946264de"
+  integrity sha512-+nZy72KGgxou/2URsWWMgP3kqrNsLZYsZvQDOAV+BDRHcKoOSzu1u8uQYNSGtzUGwaxWvIj2DDqJiVPxAnRYtA==
   dependencies:
     "@carbon/icon-helpers" "^10.7.0-rc.0"
 
-"@carbon/icons@^10.10.0-rc.0":
-  version "10.10.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/icons/-/icons-10.10.0-rc.0.tgz#1d2f5e9b2a8f3cac88ccf7730efd47e0caab520a"
-  integrity sha512-0COR12DN70+aZyS19OibN5ryUzCSdDlqdbJmkH+keTsXv7UJlVtfLTEUUes6j9ATNUenRa52JyKEnrJhl6JYlA==
+"@carbon/icons@^10.10.0-rc.1":
+  version "10.10.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/icons/-/icons-10.10.0-rc.1.tgz#83a68bd267df2843d2391130e4fe11138a8a0b88"
+  integrity sha512-pBgQy9TfQFyl9KU/twplbX3djy33yqK8MBErZP37wVyirB/WLciyDoB7hgm0oKE5raSn6DmF+/nTsUUo1fhzWg==
 
 "@carbon/import-once@^10.3.0":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@carbon/import-once/-/import-once-10.3.0.tgz#58617da4efb6d7a11352d8e6b7209da1d39f364d"
   integrity sha512-PFk3FhMe3psihYtCg3JsyPHismqglnbUqIpz1DCG5Gn/kt0HdVKhGvHdEq7E305rGoBUCKzMn/4xoY9v9mcmlg==
 
-"@carbon/layout@^10.9.0-rc.0":
-  version "10.9.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-10.9.0-rc.0.tgz#0e60577def4e259fdbf02c6da9097c54720c2868"
-  integrity sha512-CBIiy0m2DIsWUVWp1CPtNjXa+bNliRh/x29HHE6X2s1qibcUnWWtZP7y1Khkbx1RKvbuodv9j6yfXmAJBmt3hQ==
+"@carbon/layout@^10.9.0-rc.1":
+  version "10.9.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-10.9.0-rc.1.tgz#7792691046e8698cd3a3da722f03bed4f710b3f6"
+  integrity sha512-oOoKaKpLQR2Q1i8GN8e+QFI2KKNvNiO9twsZpqguo/q1z/aNREdQsJ0cc4lT2up6TSnye3doEEFdegEP3xz+ig==
 
 "@carbon/motion@^10.7.0-rc.0":
   version "10.7.0-rc.0"
   resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-10.7.0-rc.0.tgz#6cd3932c12cc1d62dab1a9df7b254b8b449e73ec"
   integrity sha512-AJLKC6sMmZixFb1MG6UjUNhrwyRI1VMInrVx9C10SCMK50CfZqvQ0wLIQmJxwwLMYnAbVrOgwL6SUngoD7BFaw==
 
-"@carbon/themes@^10.11.0-rc.0":
-  version "10.11.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-10.11.0-rc.0.tgz#e25f0c244ba1a1fcd1cd950e38b0b0d0e043f748"
-  integrity sha512-qmnPSPAyp5mSUZxVNzoo+Xv9qMIZnvBzTGFrvlLqX556lg/0km6tvMFbrbJ3vaK51N+ZBDL+4W40ZIbqdtNZ5g==
+"@carbon/themes@^10.11.0-rc.1":
+  version "10.11.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-10.11.0-rc.1.tgz#01f75435bc7214591a372562a3ff423b2c53bfda"
+  integrity sha512-C64w41sh5p4ddXHW5rSLFLJVtZ+ESgYMQEPCxqm49lipMLdprsRmqRsDyBEmrJgkSOPvBa5e/vIS4km2wuEMng==
   dependencies:
     "@carbon/colors" "^10.9.0-rc.0"
-    "@carbon/layout" "^10.9.0-rc.0"
-    "@carbon/type" "^10.10.0-rc.0"
+    "@carbon/layout" "^10.9.0-rc.1"
+    "@carbon/type" "^10.10.0-rc.1"
     color "^3.1.2"
 
-"@carbon/type@^10.10.0-rc.0":
-  version "10.10.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-10.10.0-rc.0.tgz#f3f0d09f0a1af4a3e160a299b3184636395bdbd2"
-  integrity sha512-IdwJI+sT0rBZQEBXLomxjneFdGNF/t6NZo1RYAWsxpPPufTQqmpZUXYGLhlQ+HLOjHKH/ZTCerF7V4ZJP9ryKQ==
+"@carbon/type@^10.10.0-rc.1":
+  version "10.10.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-10.10.0-rc.1.tgz#c4f606d8539a3b40185a34d3748ea7662f90848d"
+  integrity sha512-Gp9bc5qoYTOvbB/ZWcTDY8J6KbyTXkFyFkAVoLyOb6NageFcX4M0iydZ0Vr5JZBJvMzNKhPv9MMNMTG8Yp/F5A==
   dependencies:
     "@carbon/import-once" "^10.3.0"
-    "@carbon/layout" "^10.9.0-rc.0"
+    "@carbon/layout" "^10.9.0-rc.1"
 
 "@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
   version "0.1.5"
@@ -4345,12 +4345,12 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001035, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz#930ea5272010d8bf190d859159d757c0b398caf0"
   integrity sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w==
 
-carbon-components-react@^7.11.0-rc.0:
-  version "7.11.0-rc.0"
-  resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.11.0-rc.0.tgz#eed5b11370c0303cdc0c46a597406485bf095458"
-  integrity sha512-5OrxZdPO5Rn7JADd9sZ6elDL1iT23qlEMBdn2hp4UGOjRqi2L4XH16KaocwnGwis3lwphDcFdE21OqnbX+7+WQ==
+carbon-components-react@^7.11.0-rc.1:
+  version "7.11.0-rc.1"
+  resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.11.0-rc.1.tgz#5fe2737c96a4a714552d516cf56e73af0aa816f5"
+  integrity sha512-DweLlvQrvz0beoVO8bOb3fkHWsDr85HJoSYNE16kWfKS+gJpzDLcEBIbjgotwIkXB62y0YNPFltaQlN35VYGOw==
   dependencies:
-    "@carbon/icons-react" "^10.10.0-rc.0"
+    "@carbon/icons-react" "^10.10.0-rc.1"
     classnames "2.2.6"
     downshift "^1.31.14"
     flatpickr "4.6.1"
@@ -4364,10 +4364,10 @@ carbon-components-react@^7.11.0-rc.0:
     warning "^3.0.0"
     window-or-global "^1.0.1"
 
-carbon-components@^10.11.0-rc.0:
-  version "10.11.0-rc.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.11.0-rc.0.tgz#4c5622b0288b63411d78beffddb057e87ddf1684"
-  integrity sha512-QqWDpQKJaqI7AYtCKxTK9YlNmNj8ipwvnoCCO/yswA8cy/as0tua3E/DLitVywJUp4927wrq9k8pNGdoRhDNPA==
+carbon-components@^10.11.0-rc.1:
+  version "10.11.0-rc.1"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.11.0-rc.1.tgz#238159a5ddc953a487724b5aca44e77004be6193"
+  integrity sha512-Ju2FooMxCqx1vGsi4faMSh9rXCgoUf6C4FdTO8gjtK/e7mBzA/6KCK10gjPGfIQYzR3CgAWVhLjOjlcddOfnaQ==
   dependencies:
     flatpickr "4.6.1"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
The previous PR might have been merged in early, will try and keep this one up-to-date up through v10.11!

---

Update dependencies on carbon to v10.11.0-rc.1

**Release issue:** https://github.com/carbon-design-system/carbon/issues/5756
**Changelog:** https://github.com/carbon-design-system/carbon/issues/5756

#### Changelog

**New**

**Changed**

- Update dependencies on carbon to v10.11.0-rc.1

**Removed**
