### PR TITLE
Fix trailing space within feedback dialog button row.

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/Form.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/Form.module.scss
@@ -78,6 +78,7 @@
   padding-top: 1rem;
   padding-bottom: 2rem;
   width: 50%;
+  max-width: 50%;
   line-height: 1;
   border-width: 2px;
 }


### PR DESCRIPTION
When having a viewport width equal or a little lower than 671. The feedback form has a probably unintended space on the right of the bottom form button row. 
This is resulting from the max-width definition of bx--btn.

IMO a proper change would be to override the max-width with 50%.

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/8998518/78979518-54c94a00-7b1c-11ea-8931-3fff34c9cb84.png">

#### Changelog

**Changed**

- Fixed unintended space in feedback dialog button row.
