### PR TITLE
Export SwitcherDivider and SwitcherLink from Switcher

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/index.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/index.js
@@ -1,3 +1,1 @@
-import Switcher from './Switcher';
-
-export default Switcher;
+export { default, SwitcherDivider, SwitcherLink } from './Switcher';


### PR DESCRIPTION
`components/Switcher/index.js` omits to export `SwitcherDivider` and `SwitcherLink`, which are needed if you want to shadow `Switcher`.