### PR TITLE
feat: add remarkPlugins theme option

### DIFF
--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -203,6 +203,7 @@ plugins: [
 ## Additional remark plugins and override existing remark plugin configuration
 
 - `gatsbyRemarkPlugins` - An array containing gatsby remark plugin configurations to be added/overridden.
+- `remarkPlugins` - An array containing [remark plugin configurations](https://www.gatsbyjs.org/packages/gatsby-plugin-mdx/#remark-plugins) to be added.
 
 ### Example [Gatsby Remark Mermaid plugin](https://www.gatsbyjs.org/packages/gatsby-remark-mermaid/)
 
@@ -249,4 +250,39 @@ to turn into an image one should add the following configuration to her/his own 
     },
   ],
 
+```
+
+### Example [Remark Grid Tables](https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-grid-tables)
+
+For the below markdown snippet:
+
+```
++-------+----------+------+
+| Table Headings   | Here |
++-------+----------+------+
+| Sub   | Headings | Too  |
++=======+==========+======+
+| cell  | column spanning |
++ spans +----------+------+
+| rows  | normal   | cell |
++-------+----------+------+
+| multi | cells can be    |
+| line  | *formatted*     |
+|       | **paragraphs**  |
+| cells |                 |
+| too   |                 |
++-------+-----------------+
+```
+
+to turn into the table it describes one should add the following configuration to her/his own project:
+
+```js
+ plugins: [
+    {
+      resolve: 'gatsby-theme-carbon',
+      options: {
+        remarkPlugins: [require("remark-grid-tables")],
+      },
+    },
+  ],
 ```

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -205,6 +205,8 @@ plugins: [
 - `gatsbyRemarkPlugins` - An array containing gatsby remark plugin configurations to be added/overridden.
 - `remarkPlugins` - An array containing [remark plugin configurations](https://www.gatsbyjs.org/packages/gatsby-plugin-mdx/#remark-plugins) to be added.
 
+The `gatsbyRemarkPlugins` option is compatible with all gatsby-remark-* plugins, for example `gatsby-remark-mermaid`. If a gatsby remark plugin does not work, you can try calling the (underlying) remark plugin directly using the `remarkPlugins` option.
+
 ### Example [Gatsby Remark Mermaid plugin](https://www.gatsbyjs.org/packages/gatsby-remark-mermaid/)
 
 For the below markdown snippet:
@@ -274,7 +276,7 @@ For the below markdown snippet:
 +-------+-----------------+
 ```
 
-to turn into the table it describes one should add the following configuration to her/his own project:
+After installing the `remark-grid-tables` plugin, add it to the `remarkPlugins` array in the theme options.
 
 ```js
  plugins: [

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -91,9 +91,7 @@ module.exports = (themeOptions) => {
             ...defaultRemarkPlugins,
             ...gatsbyRemarkPlugins,
           ],
-          remarkPlugins: [
-            ...remarkPlugins,
-          ],
+          remarkPlugins,
           defaultLayouts: {
             default: require.resolve('./src/templates/Default.js'),
             home: require.resolve('./src/templates/Homepage.js'),

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -20,6 +20,7 @@ module.exports = (themeOptions) => {
     pngCompressionSpeed = 4, // default for gatsby-plugin-sharp
     mediumAccount = '',
     gatsbyRemarkPlugins = [],
+    remarkPlugins = [],
   } = themeOptions;
 
   const optionalPlugins = [];
@@ -89,6 +90,9 @@ module.exports = (themeOptions) => {
           gatsbyRemarkPlugins: [
             ...defaultRemarkPlugins,
             ...gatsbyRemarkPlugins,
+          ],
+          remarkPlugins: [
+            ...remarkPlugins,
           ],
           defaultLayouts: {
             default: require.resolve('./src/templates/Default.js'),


### PR DESCRIPTION
Add a [`remarkPlugins`](https://www.gatsbyjs.org/packages/gatsby-plugin-mdx/#remark-plugins) option to pass along to `gatsby-plugin-mdx`.

The reason this is required in addition to the `gatsbyRemarkPlugins` option is because `gatsbyRemarkPlugins` has had numerous issues with getting plugins to work with it:
- https://github.com/gatsbyjs/gatsby/issues/21866
- https://github.com/gatsbyjs/gatsby/issues/16983
- https://github.com/gatsbyjs/gatsby/issues/8009
- https://github.com/gatsbyjs/gatsby/issues/9103
- https://github.com/gatsbyjs/gatsby/issues/6648

But the `remarkPlugins` option works great and is usually the workaround that is eventually used. So exposing this option to the user helps.

#### Changelog

**New**

- added a `remarkPlugins` theme option to be passed to `gatsby-plugin-mdx`
- added an example on how to use it with the `remark-grid-tables` remark plugin