### PR TITLE
fix: remove listbox overrides

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.module.scss
@@ -65,23 +65,3 @@
 .tab-list li:last-of-type .tab {
   border-right: none;
 }
-
-// workaround for https://github.com/carbon-design-system/carbon/pull/4928
-:global {
-  .#{$prefix}--list-box__menu {
-    max-height: 10rem;
-    overflow-x: hidden;
-  }
-
-  .#{$prefix}--list-box__menu-item,
-  .#{$prefix}--list-box__menu-item__option,
-  .#{$prefix}--dropdown {
-    height: 3rem;
-  }
-
-  .#{$prefix}--list-box__menu-item__option {
-    width: 100%;
-    display: flex;
-    align-items: center;
-  }
-}


### PR DESCRIPTION
This is a problem downstream, our listbox overrides here impacted `Dropown`s on other pages (like IDL's icon filter row)