### PR TITLE
fix: ImageGalleryImage - change margin bottom of images from 1.5 rem …

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
@@ -1,5 +1,5 @@
 .figure {
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
 }
 
 .image-button-wrapper {


### PR DESCRIPTION
The ImageGalleryImage margins were 32-X and 24-Y. This change makes the margins equal: 32-X 32-Y

- Old look

![image](https://user-images.githubusercontent.com/24867712/82593288-eeb7f400-9baa-11ea-9d63-a142bbba59ff.png)

- New look

![image](https://user-images.githubusercontent.com/24867712/82593762-a77e3300-9bab-11ea-8eab-950744b3c38e.png)


### Changelog
---
**Changed**

- margin-bottom of figure inside ImageGalleryImage to be 2rem instead of 1.5rem
