### PR TITLE
fix: ImageGalleryImage - change margin bottom of images from 1.5 rem …

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ImageGallery/ImageGalleryImage.module.scss
@@ -1,5 +1,5 @@
 .figure {
-  margin-bottom: 1.5rem;
+  margin-bottom: $spacing-07;
 }
 
 .image-button-wrapper {


### PR DESCRIPTION
The ImageGalleryImage margins were 32-X and 24-Y. This change makes the margins equal: 32-X 32-Y

- Old look

![image](https://user-images.githubusercontent.com/24867712/82705631-ae2aaa00-9c80-11ea-933e-876261c932ff.png)


- New look

![image](https://user-images.githubusercontent.com/24867712/82705690-d1555980-9c80-11ea-87b8-feb627e0f999.png)

### Changelog
---
**Changed**

- margin-bottom of figure inside ImageGalleryImage to be $spacing-07 (2rem) instead of 1.5rem
