### PR TITLE
chore: add table to components using <Title> tag

### DIFF
--- a/packages/example/src/pages/components/Title.mdx
+++ b/packages/example/src/pages/components/Title.mdx
@@ -5,7 +5,7 @@ description: Usage instructions for the Title component
 
 <PageDescription>
 
-The `<Title>` component is used to provide a title to a subsequent component (image, video, code block). The `Title` should be used in favor of other techniques for bolded text (`h4`s) to preserve page structure and heading hierarchy.
+The `<Title>` component is used to provide a title to a subsequent component (table, image, video, code block). The `Title` should be used in favor of other techniques for bolded text (`h4`s) to preserve page structure and heading hierarchy.
 
 </PageDescription>
 


### PR DESCRIPTION
H4s and tables directly next to each other are too close visually. I think table should be mentioned here as another component which should use <Title> instead of H4 above it.


**Changed**

- added "table" to the copy