### PR TITLE
fix(ResourceCard-FeatureCard): icon was the wrong color

### DIFF
--- a/packages/example/src/pages/components/FeatureCard.mdx
+++ b/packages/example/src/pages/components/FeatureCard.mdx
@@ -16,7 +16,6 @@ The `<FeatureCard>` component takes the same props as the `<ResourceCard>` compo
   title="Title"
   actionIcon="arrowRight"
   href="/"
-  color="dark"
   >
 
 ![demo image](/images/large-image.png)

--- a/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
+++ b/packages/gatsby-theme-carbon/src/components/ResourceCard/resource-card.scss
@@ -52,6 +52,10 @@
   height: 20px;
 }
 
+.#{$prefix}--resource-card .#{$prefix}--resource-card__icon--action svg {
+  fill: $icon-01;
+}
+
 // Dark
 .#{$prefix}--resource-card--dark .#{$prefix}--tile {
   background: $carbon--gray-90; //$ui-background for gray 90 theme


### PR DESCRIPTION
Closes #883 

Targeted the SVG in the ResourceCard and gave it icon-01. Update the FeatureCard docs to have one feature card using the default color and one feature card using dark mode.