### PR TITLE
fix: Remove ".js" extension from the import in the sample code for overriding the NavItems component to avoid an infinite loop during loading

### DIFF
--- a/packages/example/src/pages/guides/navigation/sidebar.mdx
+++ b/packages/example/src/pages/guides/navigation/sidebar.mdx
@@ -60,7 +60,7 @@ Simply provide your own implementation of `/src/util/NavItems.js` which can augm
 
 ```javascript
 // /src/util/NavItems.js
-import { useNavItems as themeUseNavItems } from 'gatsby-theme-carbon/src/util/NavItems.js';
+import { useNavItems as themeUseNavItems } from 'gatsby-theme-carbon/src/util/NavItems';
 
 // add nav items
 export function useNavItems() {


### PR DESCRIPTION
Closes #908

fix: Remove ".js" extension from the import in the sample code for overriding the NavItems component to avoid an infinite loop during loading, resolves #908

#### Changelog

**New**

- none

**Changed**

- Changed sample code for NavItems component.

**Removed**

- none
