### PR TITLE
fix(GlobalSearch): add conditional set to aria-activedescendent

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
@@ -142,6 +142,16 @@ const GlobalSearchInput = () => {
     }
   };
 
+  // Check if there are results, if there are the listbox is open
+  // and set focus to the first menu item
+  const getAriaActiveDescendantValue = () => {
+    if (results.length > 0) {
+      return `menu-item-${focusedItem}`;
+    }
+
+    return null;
+  };
+
   return (
     <MenuContext.Provider value={value}>
       <div
@@ -182,7 +192,7 @@ const GlobalSearchInput = () => {
             type="text"
             aria-autocomplete="list"
             aria-controls="search-menu"
-            aria-activedescendant={`menu-item-${focusedItem}`}
+            aria-activedescendant={getAriaActiveDescendantValue()}
             className={cx(input, {
               [hidden]: !searchIsOpen,
             })}


### PR DESCRIPTION
Updates GlobalSearch to conditionally set `aria-activedescendent`. Before with no results available `aria-activedescendent` was set incorrectly to 0 even with the listbox closed which was causing an error in the Accessibility Checker because the ID referenced had no corresponding list item. 

Now it's only set to a list item id when results are present :surfer: 

## To test
1) Go to the theme demo
2) Confirm that `aria-activedescendent` isn't present on the GlobalSearch's `<input>`
3) Type any letter to get some search results and reveal the listbox
4) Confirm that `aria-activedescdendent` is set to 0 on the GlobalSearch's `<input>`
5) Confirm no errors in Accessibility Checker pertaining to `aria-activedescendent`