### PR TITLE
chore(standards): adding the standards website to the Switcher

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -73,6 +73,9 @@ const DefaultChildren = () => (
       IBM Design Language
     </SwitcherLink>
     <SwitcherLink href="https://ibm.com/brand">IBM Brand Center</SwitcherLink>
+    <SwitcherLink href="https://www.ibm.com/standards/web/">
+      IBM Web Standards
+    </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/able/">
       IBM Accessibility
     </SwitcherLink>
@@ -80,7 +83,7 @@ const DefaultChildren = () => (
     <SwitcherLink href="https://www.carbondesignsystem.com/">
       Product
     </SwitcherLink>
-    <SwitcherLink href="https://www.ibm.com/standards/web/">
+    <SwitcherLink href="https://www.ibm.com/standards/web/ibm-dotcom-library">
       Digital
     </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/design/event/">Event</SwitcherLink>


### PR DESCRIPTION
The `Digital` link now links to the IBM.com Library website, and also
adding a separate link to the overall Standards website for IBM

#### Changelog

**Changed**

- Updated entries in the `Switcher`