### PR TITLE
Permit overwrite of MdxNode field addition to page context

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-node.js
+++ b/packages/gatsby-theme-carbon/gatsby-node.js
@@ -25,24 +25,26 @@ exports.onCreatePage = (
   { page, actions, getNodesByType, ...rest },
   pluginOptions
 ) => {
-  // Find the MdxNode that created our page
-  const MdxNode = getNodesByType('Mdx').find(
-    ({ fileAbsolutePath }) => fileAbsolutePath === page.component
-  );
+  if(!page.context.MdxNode){ // Enable the possibility to overwrite it
+    // Find the MdxNode that created our page
+    const MdxNode = getNodesByType('Mdx').find(
+      ({ fileAbsolutePath }) => fileAbsolutePath === page.component
+    );
 
-  const { titleType = 'page' } = pluginOptions;
-  const { createPage, deletePage } = actions;
-  const [relativePagePath] = page.componentPath.split('src/pages').splice('-1');
-  deletePage(page);
-  createPage({
-    ...page,
-    context: {
-      ...page.context,
-      relativePagePath,
-      titleType,
-      MdxNode,
-    },
-  });
+    const { titleType = 'page' } = pluginOptions;
+    const { createPage, deletePage } = actions;
+    const [relativePagePath] = page.componentPath.split('src/pages').splice('-1');
+    deletePage(page);
+    createPage({
+      ...page,
+      context: {
+        ...page.context,
+        relativePagePath,
+        titleType,
+        MdxNode,
+      },
+    });
+  }
 };
 
 // In the case where none of the nav items have child pages, an error occurs in the left nav

--- a/packages/gatsby-theme-carbon/gatsby-node.js
+++ b/packages/gatsby-theme-carbon/gatsby-node.js
@@ -25,7 +25,8 @@ exports.onCreatePage = (
   { page, actions, getNodesByType, ...rest },
   pluginOptions
 ) => {
-  if(!page.context.MdxNode){ // Enable the possibility to overwrite it
+  // Don't override if it's already been provided
+  if(!page.context.MdxNode){
     // Find the MdxNode that created our page
     const MdxNode = getNodesByType('Mdx').find(
       ({ fileAbsolutePath }) => fileAbsolutePath === page.component

--- a/packages/gatsby-theme-carbon/gatsby-node.js
+++ b/packages/gatsby-theme-carbon/gatsby-node.js
@@ -26,7 +26,7 @@ exports.onCreatePage = (
   pluginOptions
 ) => {
   // Don't override if it's already been provided
-  if(!page.context.MdxNode){
+  if (!page.context.MdxNode) {
     // Find the MdxNode that created our page
     const MdxNode = getNodesByType('Mdx').find(
       ({ fileAbsolutePath }) => fileAbsolutePath === page.component
@@ -34,7 +34,9 @@ exports.onCreatePage = (
 
     const { titleType = 'page' } = pluginOptions;
     const { createPage, deletePage } = actions;
-    const [relativePagePath] = page.componentPath.split('src/pages').splice('-1');
+    const [relativePagePath] = page.componentPath
+      .split('src/pages')
+      .splice('-1');
     deletePage(page);
     createPage({
       ...page,


### PR DESCRIPTION
The block of code doesn't work in conjunction with some customization (e.g. when `page.component` is defined to point to a template or when pages are not in `src/pages`. Adding a blog to avoid re-running the block of code if the MdxNode has been already defined will permit to create additional `onCreatePage` method to apply custom logic.

#### Changelog

**Changed**

- gatsby-node.js
