### PR TITLE
chore(switcher): removing web standards url per request

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -96,9 +96,6 @@ const DefaultChildren = () => (
     <SwitcherLink href="https://www.ibm.com/able/">
       IBM Accessibility
     </SwitcherLink>
-    <SwitcherLink href="https://www.ibm.com/standards/web/">
-      IBM Web Standards
-    </SwitcherLink>
     <SwitcherDivider>Design disciplines</SwitcherDivider>
     <SwitcherLink href="https://www.carbondesignsystem.com/">
       Product


### PR DESCRIPTION
Closes #

Refs #984 

#### Changelog

**Removed**

- Removed `IBM Web Standards` url from the switcher
