### PR TITLE
fix: feedback button colors

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
@@ -23,6 +23,7 @@
 .button:focus {
   outline: none;
   border: 2px solid $focus;
+  box-shadow: inset 0 0 0 1px $inverse-01;
 }
 
 .button svg {

--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
@@ -2,21 +2,24 @@
   width: $spacing-09;
   height: $spacing-09;
   border-radius: 50%;
-  background: $carbon--gray-30;
+  background: $active-secondary; //g60
   border-color: transparent;
   position: fixed;
   bottom: $spacing-09;
   right: $spacing-07;
   transition: all $duration--fast-02;
-
   cursor: pointer;
   z-index: z('modal');
   padding-top: 0.325rem;
   color: $text-01;
 }
 
+.button svg {
+  fill: $icon-03;
+}
+
 .button:hover {
-  background: $inverse-01;
+  background: $inverse-hover-ui; //g80 hover
   border-color: transparent;
 }
 
@@ -24,8 +27,4 @@
   outline: none;
   border: 2px solid $focus;
   box-shadow: inset 0 0 0 1px $inverse-01;
-}
-
-.button svg {
-  fill: $carbon--black-100;
 }

--- a/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/BackToTopBtn/BackToTopBtn.module.scss
@@ -2,16 +2,15 @@
   width: $spacing-09;
   height: $spacing-09;
   border-radius: 50%;
-  background: $active-secondary; //g60
   border-color: transparent;
+  background: $interactive-02; //g60
+  transition: all $duration--fast-02;
+  z-index: z('modal');
+  padding-top: 0.325rem;
+  cursor: pointer;
   position: fixed;
   bottom: $spacing-09;
   right: $spacing-07;
-  transition: all $duration--fast-02;
-  cursor: pointer;
-  z-index: z('modal');
-  padding-top: 0.325rem;
-  color: $text-01;
 }
 
 .button svg {
@@ -19,12 +18,20 @@
 }
 
 .button:hover {
-  background: $inverse-hover-ui; //g80 hover
-  border-color: transparent;
+  background: $hover-secondary; // g80 hover
 }
 
 .button:focus {
   outline: none;
-  border: 2px solid $focus;
+  border: 2px solid var(--cds-inverse-focus-ui);
   box-shadow: inset 0 0 0 1px $inverse-01;
+}
+
+[class*='container--dark'] {
+  .button {
+    background: $carbon--gray-60;
+    &:hover {
+      background: #606060;
+    }
+  }
 }

--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/FeedbackDialog.js
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/FeedbackDialog.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { FaceWink20, FaceWinkFilled20 } from '@carbon/icons-react';
+import { FaceWink20 } from '@carbon/icons-react';
 
 import LaunchButton from './LaunchButton';
 import Form from './Form';
@@ -14,7 +14,6 @@ const FeedbackDialog = ({ onSubmit }) => {
       <LaunchButton
         visible={visible}
         icon={FaceWink20}
-        filledIcon={FaceWinkFilled20}
         onClick={() => setVisible(!visible)}
       />
     </>

--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.js
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.js
@@ -2,12 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import styles from './LaunchButton.module.scss';
 
-function LaunchButton({
-  onClick,
-  visible,
-  icon: RegularIcon,
-  filledIcon: FilledIcon,
-}) {
+function LaunchButton({ onClick, visible, icon: RegularIcon }) {
   const classNames = cx(styles.button, {
     [styles.selected]: visible,
   });
@@ -19,7 +14,7 @@ function LaunchButton({
       className={classNames}
       onClick={onClick}
       aria-label="This launches a modal form to give website feedback.">
-      {visible ? <FilledIcon /> : <RegularIcon />}
+      <RegularIcon />
     </button>
   );
 }

--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
@@ -3,39 +3,26 @@
   height: $spacing-09;
   border-radius: 50%;
   border-color: transparent;
-  background: $carbon--gray-30;
+  background: $active-secondary; //g60
   transition: all $duration--fast-02;
   z-index: z('modal');
   padding-top: 0.325rem;
-
   cursor: pointer;
-
   position: fixed;
   bottom: calc(6rem + 8px);
   right: $spacing-07;
+}
+
+.button svg {
+  fill: $icon-03;
+}
+
+.button:hover {
+  background: $inverse-hover-ui; // g80 hover
 }
 
 .button:focus {
   outline: none;
   border: 2px solid var(--cds-inverse-focus-ui);
   box-shadow: inset 0 0 0 1px $inverse-01;
-}
-
-.button svg {
-  fill: $carbon--black-100;
-}
-
-//unselected state hover + selected state (non-hover) #886
-.button:hover,
-.button.selected {
-  background: $inverse-01; // gray-60 hover
-}
-
-//selected state hover
-.button.selected:hover {
-  background: var(--cds-interactive-02);
-}
-
-.button.selected:hover svg {
-  fill: $icon-03;
 }

--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
@@ -3,7 +3,7 @@
   height: $spacing-09;
   border-radius: 50%;
   border-color: transparent;
-  background: $active-secondary; //g60
+  background: $interactive-02; //g60
   transition: all $duration--fast-02;
   z-index: z('modal');
   padding-top: 0.325rem;
@@ -18,11 +18,20 @@
 }
 
 .button:hover {
-  background: $inverse-hover-ui; // g80 hover
+  background: $hover-secondary; // g80 hover
 }
 
 .button:focus {
   outline: none;
   border: 2px solid var(--cds-inverse-focus-ui);
   box-shadow: inset 0 0 0 1px $inverse-01;
+}
+
+[class*='container--dark'] {
+  .button {
+    background: $carbon--gray-60;
+    &:hover {
+      background: #606060;
+    }
+  }
 }

--- a/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/FeedbackDialog/LaunchButton.module.scss
@@ -3,7 +3,7 @@
   height: $spacing-09;
   border-radius: 50%;
   border-color: transparent;
-  background: var(--cds-interactive-02);
+  background: $carbon--gray-30;
   transition: all $duration--fast-02;
   z-index: z('modal');
   padding-top: 0.325rem;
@@ -15,20 +15,27 @@
   right: $spacing-07;
 }
 
-.button:hover {
-  background: var(--cds-inverse-01); // gray-60 hover
+.button:focus {
+  outline: none;
+  border: 2px solid var(--cds-inverse-focus-ui);
+  box-shadow: inset 0 0 0 1px $inverse-01;
 }
 
+.button svg {
+  fill: $carbon--black-100;
+}
+
+//unselected state hover + selected state (non-hover) #886
+.button:hover,
+.button.selected {
+  background: $inverse-01; // gray-60 hover
+}
+
+//selected state hover
 .button.selected:hover {
   background: var(--cds-interactive-02);
 }
 
-.button:focus {
-  outline: none;
-  border: 2px solid var(--cds-inverse-focus-ui);
-  box-shadow: inset 0 0 0 1px #fff;
-}
-
-.button svg {
-  fill: var(--cds-icon-03);
+.button.selected:hover svg {
+  fill: $icon-03;
 }

--- a/packages/gatsby-theme-carbon/src/templates/Homepage.js
+++ b/packages/gatsby-theme-carbon/src/templates/Homepage.js
@@ -3,6 +3,7 @@ import Layout from '../components/Layout';
 import { HomepageBanner, HomepageCallout } from '../components/Homepage';
 import Carbon from '../images/carbon.jpg';
 import Main from '../components/Main';
+import Utils from '../components/Utils';
 
 import BackToTopBtn from '../components/BackToTopBtn';
 import NextPrevious from '../components/NextPrevious';
@@ -31,7 +32,7 @@ const Homepage = ({
       <Main>{children}</Main>
       {SecondCallout}
       <NextPrevious isHomepage location={location} pageContext={pageContext} />
-      <BackToTopBtn />
+      <Utils />
     </Layout>
   );
 };


### PR DESCRIPTION
Closes #886 


**Changed**

- closed state launch btn now matches `BackToTop` btn color
- expanded state background color now matches closed state hover color
- added a white box-shadow to `BackToTop` btn focus state to match feedback launch btn focus state

**Removed**
- filled face icon for launch btn
