### PR TITLE
fix: switcher aria label text

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -44,7 +44,7 @@ const Switcher = ({ children }) => {
   return (
     <nav
       className={cx(nav, { [open]: switcherIsOpen })}
-      aria-label="IBM Design ecosystem navigation"
+      aria-label="IBM Design ecosystem"
       tabIndex="-1"
       style={{ maxHeight }}>
       <ul ref={listRef}>{children}</ul>


### PR DESCRIPTION
Closes #847

- updating aria label so it won't be redundant for screen reader
