### PR TITLE
fix(navigation): use proper apostrophe/quote syntax

### DIFF
--- a/packages/example/src/pages/guides/navigation/tabs.mdx
+++ b/packages/example/src/pages/guides/navigation/tabs.mdx
@@ -68,7 +68,7 @@ grammatically correct text in the frontmatter. Your file name and
 ```markdown
 ---
 title: Sidebar
-tabs: ['Sidebar', 'What’s new']
+tabs: ['Sidebar', "What’s new"]
 ---
 ```
 


### PR DESCRIPTION
Following the existing guidance on tabs with apostrophes with `gatsby@2.24.67` results in an error:
```
ERROR #11321  PLUGIN

"gatsby-plugin-mdx" threw an error while running the onCreateNode lifecycle:

missed comma between flow collection entries at line 7, column 11:
        'What's new',
              ^/Users/taylorjones/dev/ibm/design/src/pages/team/content-design/knowledge-center/whats-new.mdx: missed comma between flow collection entries at line 7, column 11:
        'What's new',
              ^

  31 |   const createAndProcessNode = path => {
  32 |     const fileNodePromise = createFileNode(path, createNodeId, pluginOptions).then(fileNode => {
> 33 |       createNode(fileNode);
     |       ^
  34 |       return null;
  35 |     });
  36 |     return fileNodePromise;

File: node_modules/gatsby-source-filesystem/gatsby-node.js:33:7



  YAMLException: missed comma between flow collection entries at line 7, column 11:
          'What's new',
                ^
  
```

If you wrap the string in double quotes instead of single quotes the error is resolved

#### Changelog

**Changed**

- fixed syntax in docs regarding tabs with apostrophes

