### PR TITLE
docs: changed all references of master --> main, due to new default b…

### DIFF
--- a/packages/example/src/pages/components/FeedbackDialog.mdx
+++ b/packages/example/src/pages/components/FeedbackDialog.mdx
@@ -41,7 +41,7 @@ export default FeedbackDialog;
 Next, you'll need a place to send the data. For the Carbon website, we use a
 serverless function that forwards the data to a
 [SurveyGizmo](https://www.surveygizmo.com/) quiz. You can see that function
-[here](https://github.com/carbon-design-system/carbon-website/blob/master/api/survey.ts).
+[here](https://github.com/carbon-design-system/carbon-website/blob/main/api/survey.ts).
 
 The handler can send a fetch request off to the endpoint you create. Update the
 `onSubmit` handler to send the data wherever you want. This function receives

--- a/packages/example/src/pages/components/Grid.mdx
+++ b/packages/example/src/pages/components/Grid.mdx
@@ -8,7 +8,7 @@ description: Usage instructions for the Grid component
 `<Row>` and `<Column>` components are used to arrange content and components on
 the grid within a page. To learn more about the grid is built, you can read the
 docs in the
-[Carbon](https://github.com/carbon-design-system/carbon/tree/master/packages/grid)
+[Carbon](https://github.com/carbon-design-system/carbon/tree/main/packages/grid)
 repo.
 
 </PageDescription>

--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -53,6 +53,6 @@ This code snippet provides both a `path` and a `src`.
 
 | property | propType | description                                                                                                                 |
 | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| language | string   | [Available languages.](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js) |
+| language | string   | [Available languages.](https://github.com/FormidableLabs/prism-react-renderer/blob/main/src/vendor/prism/includeLangs.js) |
 | src      | string   | The full url of a relevant link (source)                                                                                    |
 | path     | string   | A string indicating the filename or path. Due to markdown limitations this can only be a single word                        |

--- a/packages/example/src/pages/components/markdown.mdx
+++ b/packages/example/src/pages/components/markdown.mdx
@@ -202,7 +202,7 @@ there.
 ````
 
 You can view a list of included languages at the
-[react-prism-renderer repo](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+[react-prism-renderer repo](https://github.com/FormidableLabs/prism-react-renderer/blob/main/src/vendor/prism/includeLangs.js).
 
 ## Tables
 

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -346,7 +346,7 @@ project:
 
 ```
 
-### Example [Remark Grid Tables](https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-grid-tables)
+### Example [Remark Grid Tables](https://github.com/zestedesavoir/zmarkdown/tree/main/packages/remark-grid-tables)
 
 For the below markdown snippet:
 

--- a/packages/example/src/pages/guides/hosting.mdx
+++ b/packages/example/src/pages/guides/hosting.mdx
@@ -38,4 +38,4 @@ hosted applications and is provided to all IBMers.
 ### Examples
 
 [https://w3.ibm.com/design](https://w3.ibm.com/design) -
-[View configuration](https://github.ibm.com/Design/w3-design/blob/master/Dockerfile)
+[View configuration](https://github.ibm.com/Design/w3-design/blob/main/Dockerfile)

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -12,7 +12,7 @@ module.exports = (themeOptions) => {
   const repositoryDefault = {
     baseUrl: '',
     subDirectory: '',
-    branch: 'master',
+    branch: 'main',
   };
 
   const defaultTheme = { homepage: 'dark', interior: 'g10' };

--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
@@ -1,6 +1,6 @@
 // Gatsby doesn't include the recommended exceptions to this rule
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
+// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
 
 import React, { useEffect, createContext, useContext } from 'react';
 import { Link } from 'gatsby';

--- a/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-carbon/src/components/Tabs/Tabs.js
@@ -1,6 +1,6 @@
 // Gatsby doesn't include the recommended exceptions to this rule
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
+// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-to-interactive-role.md#rule-details
 
 import React, {
   useContext,


### PR DESCRIPTION
…ranch

Closes #

Some references to master still exist. In fact, they occur many times in the user-facing docs. Check the github links at: https://gatsby-theme-carbon.now.sh/guides/configuration/
<img width="1676" alt="Screen Shot 2020-10-27 at 8 57 42 AM" src="https://user-images.githubusercontent.com/16977711/97319425-7c6ece00-1832-11eb-8c7c-195bd7fafbb4.png">


#### Changelog

**New**

- {{new thing}}

**Changed**

- references to 'main'

**Removed**

- references to 'master'
