### PR TITLE
docs: fix typo in npm-scripts.mdx

### DIFF
--- a/packages/example/src/pages/guides/npm-scripts.mdx
+++ b/packages/example/src/pages/guides/npm-scripts.mdx
@@ -6,7 +6,7 @@ description:
 
 <PageDescription>
 
-Site's built with the Carbon Gatsby theme starter come ready to go with some
+Sites built with the Carbon Gatsby theme starter come ready to go with some
 helpful npm scripts. You can run these commands by typing `yarn [command]` or
 `npm run [command]`
 

--- a/packages/gatsby-theme-carbon/src/components/Footer/Footer.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Footer/Footer.module.scss
@@ -25,7 +25,7 @@
     @include carbon--breakpoint('sm') {
       content: '';
       background: $carbon--gray-80;
-      width: calc(100% - 2rem);
+      width: 100%;
       height: 1px;
       display: block;
       position: absolute;


### PR DESCRIPTION
The word _Sites_ at the beginning should be plural, and not _Site's_.