### PR TITLE
fix(switcher): added reid and universal experiences sites

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -103,7 +103,7 @@ const DefaultChildren = () => (
       Carbon Design System
     </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/">
-      Carbon for IBM.com 
+      Carbon for IBM.com
     </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/design/event/">
       IBM Event Design
@@ -127,6 +127,14 @@ const DefaultChildren = () => (
     <SwitcherDivider>Community</SwitcherDivider>
     <SwitcherLink href="https://w3.ibm.com/design/" isInternal>
       IBM Design
+    </SwitcherLink>
+    <SwitcherLink href="https://w3.ibm.com/design/careerplaybook" isInternal>
+      IBM Design Career Playbook
+    </SwitcherLink>
+    <SwitcherLink
+      href="https://w3.ibm.com/design/racial-equity-in-design"
+      isInternal>
+      Racial Equity in Design
     </SwitcherLink>
   </>
 );

--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -124,16 +124,16 @@ const DefaultChildren = () => (
     <SwitcherLink href="https://www.ibm.com/services/ibmix/">
       IBM iX
     </SwitcherLink>
+    <SwitcherLink
+      href="https://w3.ibm.com/design/universal-experiences/"
+      isInternal>
+      IBM Universal Experiences
+    </SwitcherLink>
     <SwitcherDivider>Community</SwitcherDivider>
     <SwitcherLink href="https://w3.ibm.com/design/" isInternal>
       IBM Design
     </SwitcherLink>
-    <SwitcherLink href="https://w3.ibm.com/design/careerplaybook" isInternal>
-      IBM Design Career Playbook
-    </SwitcherLink>
-    <SwitcherLink
-      href="https://w3.ibm.com/design/racial-equity-in-design"
-      isInternal>
+    <SwitcherLink href="https://w3.ibm.com/design/racial-equity-in-design">
       Racial Equity in Design
     </SwitcherLink>
   </>


### PR DESCRIPTION
Closes [#107](https://github.ibm.com/Design/racial-equity-in-design/issues/107)

Added Racial Equity in Design and the Universal Experiences sites to the Switcher.

DON'T MERGE UNTIL REiD GOES PUBLIC