### PR TITLE
Update Header.module.scss

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -73,6 +73,7 @@ header.header {
   border-top: 1px solid transparent;
   display: flex;
   align-items: center;
+  z-index: 1;
   &:focus {
     outline: 2px solid $carbon--white-0;
     outline-offset: -2px;


### PR DESCRIPTION
Closes #1073

The Header's name is clickable again.