### PR TITLE
fix: 404 link color and config branch as main

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -12,7 +12,7 @@ module.exports = (themeOptions) => {
   const repositoryDefault = {
     baseUrl: '',
     subDirectory: '',
-    branch: 'master',
+    branch: 'main',
   };
 
   const defaultTheme = { homepage: 'dark', interior: 'g10' };

--- a/packages/gatsby-theme-carbon/src/components/FourOhFour/FourOhFour.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/FourOhFour/FourOhFour.module.scss
@@ -22,7 +22,7 @@
   position: relative;
   display: inline-block;
   transition: color $transition--base;
-  color: white;
+  color: $text-01;
   text-decoration: none;
   margin-left: $spacing-05;
 
@@ -37,7 +37,7 @@
     content: '\21B3'; //"↳"
     position: absolute;
     left: -$spacing-05;
-    color: white;
+    color: $text-01;
     transition: color $transition--base;
     cursor: pointer;
   }


### PR DESCRIPTION
Closes #1042 
Closes #1069 

#### Changelog

- updates gatsby-config to point to main branch instead of master 
- changes color token for anchor links in 404 page (tested with diff themes)
<img width="725" alt="Screen Shot 2021-01-07 at 12 50 05 PM" src="https://user-images.githubusercontent.com/32556167/103932520-9147c780-50e7-11eb-968f-3499632aa66f.png">

<img width="680" alt="Screen Shot 2021-01-07 at 12 06 21 PM" src="https://user-images.githubusercontent.com/32556167/103932516-90af3100-50e7-11eb-8a93-06d2c5e5688e.png">

<img width="627" alt="Screen Shot 2021-01-07 at 12 03 07 PM" src="https://user-images.githubusercontent.com/32556167/103932514-8ee56d80-50e7-11eb-9444-53432c9095c3.png">
