### PR TITLE
style: fixes z-index when search is open

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -5,6 +5,7 @@
   top: 0;
   right: 0;
   width: calc(100% - 3rem);
+  z-index: 2;
   @include carbon--breakpoint('lg') {
     position: static;
     width: auto;
@@ -109,7 +110,7 @@ header.header {
   border-top: 1px solid transparent;
   display: flex;
   align-items: center;
-  z-index: 1;
+  z-index: 3;
   &:focus {
     outline: 2px solid $carbon--white-0;
     outline-offset: -2px;
@@ -119,6 +120,10 @@ header.header {
     left: 0;
     max-width: 384px;
   }
+}
+
+.collapsed {
+  z-index: 1;
 }
 
 .header .header-button {


### PR DESCRIPTION
Closes #1086 

I was able to use some leftover header code to add/remove style with the search is clicked.

To test make sure you can open and use search on all screen sizes. Also make sure the header, titled "Gatsby Theme Carbon" can be clicked on and returns you to the root of the site.