### PR TITLE
feat: last modified date on pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 # Logs
-logs
-*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Logs
+logs
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -27,7 +27,7 @@ module.exports = {
             'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
         },
-        pageModifiedDates: true,
+        pageModifiedDate: true,
       },
     },
   ],

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
             'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
         },
+        pageModifiedDates: true,
       },
     },
   ],

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -5,7 +5,6 @@ description: Guide for configuring the theme’s various settings
 
 <PageDescription>
 
-
 Gatsby themes allow you to override configuration from the theme by defining the
 same property in your `gatsby-config.js` at the root of your project. You can
 see the default configuration provided by the theme’s
@@ -13,7 +12,6 @@ see the default configuration provided by the theme’s
 file.
 
 </PageDescription>
-
 
 <AnchorLinks>
   <AnchorLink>Site metadata</AnchorLink>
@@ -25,6 +23,7 @@ file.
   <AnchorLink>Navigation style</AnchorLink>
   <AnchorLink>Edit on Github link</AnchorLink>
   <AnchorLink>Medium</AnchorLink>
+  <AnchorLink>Page modified date</AnchorLink>
   <AnchorLink>Other options</AnchorLink>
 </AnchorLinks>
 
@@ -203,12 +202,10 @@ When enabled, your header navigation will look like the image below:
 <Row>
 <Column colMd={8} colLg={8}>
 
-
 ![Header navigation style](header-nav-config.jpg)
 
 </Column>
 </Row>
-
 
 With the header navigation style enabled, the content on your page will be
 further left-aligned to allow for more content space.
@@ -253,6 +250,23 @@ plugins: [
     resolve: 'gatsby-theme-carbon',
     options: {
       mediumAccount: 'carbondesign',
+    },
+  },
+];
+```
+
+## Page modified date
+
+By enabling this feature, a timestamp will appear in the lower-left corner of
+all inner pages (not the home page) indicating the last date an author committed
+that page to git.
+
+```js
+plugins: [
+  {
+    resolve: 'gatsby-theme-carbon',
+    options: {
+      pageModifiedDate: true,
     },
   },
 ];

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -18,6 +18,7 @@ module.exports = (themeOptions) => {
   const defaultTheme = { homepage: 'dark', interior: 'g10' };
 
   const {
+    pageModifiedDate = false,
     theme: themeOption,
     isSearchEnabled = true,
     navigationStyle = '',
@@ -73,6 +74,7 @@ module.exports = (themeOptions) => {
 
   return {
     siteMetadata: {
+      pageModifiedDate,
       isSearchEnabled,
       navigationStyle,
       homepageTheme: theme.homepage,

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
@@ -6,8 +6,6 @@ import useMetadata from '../../util/hooks/useMetadata';
 const ModifiedDate = (gitDate) => {
   const { pageModifiedDate } = useMetadata();
 
-  console.log(pageModifiedDate);
-
   const chonkyDate = gitDate.gitDate.gitDate;
 
   const date = chonkyDate.split('T')[0];

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Row, Column } from '../Grid';
 import styles from './modified-date.module.scss';
+import useMetadata from '../../util/hooks/useMetadata';
 
 const ModifiedDate = (gitDate) => {
+  const { pageModifiedDate } = useMetadata();
+
+  console.log(pageModifiedDate);
+
   const chonkyDate = gitDate.gitDate.gitDate;
 
   const date = chonkyDate.split('T')[0];
 
-  return (
+  return pageModifiedDate ? (
     <Row className={styles.row}>
       <Column>
         <div className={styles.text}>Page last updated: {date}</div>
       </Column>
     </Row>
-  );
+  ) : null;
 };
 
 export default ModifiedDate;

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
@@ -8,7 +8,7 @@ const ModifiedDate = (gitDate) => {
   const date = chonkyDate.split('T')[0];
 
   return (
-    <Row>
+    <Row className={styles.row}>
       <Column>
         <div className={styles.text}>Page last updated: {date}</div>
       </Column>

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/ModifiedDate.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Row, Column } from '../Grid';
+import styles from './modified-date.module.scss';
+
+const ModifiedDate = (gitDate) => {
+  const chonkyDate = gitDate.gitDate.gitDate;
+
+  const date = chonkyDate.split('T')[0];
+
+  return (
+    <Row>
+      <Column>
+        <div className={styles.text}>Page last updated: {date}</div>
+      </Column>
+    </Row>
+  );
+};
+
+export default ModifiedDate;

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/index.js
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/index.js
@@ -1,0 +1,3 @@
+import ModifiedDate from './ModifiedDate';
+
+export default ModifiedDate;

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/modified-date.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/modified-date.module.scss
@@ -1,3 +1,8 @@
 .text {
   @include carbon--type-style('body-short-01');
 }
+
+.row {
+  position: relative;
+  top: 5rem;
+}

--- a/packages/gatsby-theme-carbon/src/components/ModifiedDate/modified-date.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ModifiedDate/modified-date.module.scss
@@ -1,0 +1,3 @@
+.text {
+  @include carbon--type-style('body-short-01');
+}

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -9,10 +9,16 @@ import EditLink from '../components/EditLink';
 import NextPrevious from '../components/NextPrevious';
 import PageTabs from '../components/PageTabs';
 import Main from '../components/Main';
+import ModifiedDate from '../components/ModifiedDate';
 import useMetadata from '../util/hooks/useMetadata';
 
 const Default = ({ pageContext, children, location, Title }) => {
-  const { frontmatter = {}, relativePagePath, titleType } = pageContext;
+  const {
+    frontmatter = {},
+    relativePagePath,
+    titleType,
+    MdxNode: { fields: gitDate },
+  } = pageContext;
   const {
     tabs,
     title,
@@ -21,6 +27,7 @@ const Default = ({ pageContext, children, location, Title }) => {
     keywords,
   } = frontmatter;
 
+  console.log(pageContext);
   const { interiorTheme } = useMetadata();
 
   // get the path prefix if it exists
@@ -46,7 +53,6 @@ const Default = ({ pageContext, children, location, Title }) => {
       slugify(tabs[0], { lower: true })
     );
   };
-
   const currentTab = getCurrentTab();
 
   const theme = frontmatterTheme || interiorTheme;
@@ -77,6 +83,7 @@ const Default = ({ pageContext, children, location, Title }) => {
       <Main padded>
         {children}
         <EditLink relativePagePath={relativePagePath} />
+        <ModifiedDate gitDate={gitDate} />
       </Main>
       <NextPrevious
         pageContext={pageContext}

--- a/packages/gatsby-theme-carbon/src/templates/Default.js
+++ b/packages/gatsby-theme-carbon/src/templates/Default.js
@@ -27,7 +27,6 @@ const Default = ({ pageContext, children, location, Title }) => {
     keywords,
   } = frontmatter;
 
-  console.log(pageContext);
   const { interiorTheme } = useMetadata();
 
   // get the path prefix if it exists

--- a/packages/gatsby-theme-carbon/src/templates/Homepage.js
+++ b/packages/gatsby-theme-carbon/src/templates/Homepage.js
@@ -5,6 +5,7 @@ import Carbon from '../images/carbon.jpg';
 import Main from '../components/Main';
 import useMetadata from '../util/hooks/useMetadata';
 import Utils from '../components/Utils';
+import ModifiedDate from '../components/ModifiedDate';
 
 import NextPrevious from '../components/NextPrevious';
 
@@ -16,8 +17,13 @@ const Homepage = ({
   location,
   pageContext,
 }) => {
-  const { frontmatter = {}, titleType } = pageContext;
+  const {
+    frontmatter = {},
+    titleType,
+    MdxNode: { fields: gitDate },
+  } = pageContext;
   const { title, description, keywords } = frontmatter;
+
   const { homepageTheme } = useMetadata();
 
   return (
@@ -32,6 +38,8 @@ const Homepage = ({
       {FirstCallout}
       <Main>{children}</Main>
       {SecondCallout}
+      <ModifiedDate gitDate={gitDate} />
+
       <NextPrevious isHomepage location={location} pageContext={pageContext} />
       <Utils />
     </Layout>

--- a/packages/gatsby-theme-carbon/src/templates/Homepage.js
+++ b/packages/gatsby-theme-carbon/src/templates/Homepage.js
@@ -5,7 +5,6 @@ import Carbon from '../images/carbon.jpg';
 import Main from '../components/Main';
 import useMetadata from '../util/hooks/useMetadata';
 import Utils from '../components/Utils';
-import ModifiedDate from '../components/ModifiedDate';
 
 import NextPrevious from '../components/NextPrevious';
 
@@ -17,11 +16,7 @@ const Homepage = ({
   location,
   pageContext,
 }) => {
-  const {
-    frontmatter = {},
-    titleType,
-    MdxNode: { fields: gitDate },
-  } = pageContext;
+  const { frontmatter = {}, titleType } = pageContext;
   const { title, description, keywords } = frontmatter;
 
   const { homepageTheme } = useMetadata();
@@ -38,8 +33,6 @@ const Homepage = ({
       {FirstCallout}
       <Main>{children}</Main>
       {SecondCallout}
-      <ModifiedDate gitDate={gitDate} />
-
       <NextPrevious isHomepage location={location} pageContext={pageContext} />
       <Utils />
     </Layout>

--- a/packages/gatsby-theme-carbon/src/util/hooks/useMetadata.js
+++ b/packages/gatsby-theme-carbon/src/util/hooks/useMetadata.js
@@ -13,6 +13,7 @@ const useMetadata = () => {
           interiorTheme
           navigationStyle
           lang
+          pageModifiedDate
         }
       }
     }


### PR DESCRIPTION
Users now have the option of enabling or disabling a feature to display the last time a page was modified and committed to git on Inner pages, giving users clarity on when the last time a given page was updated.

![image](https://user-images.githubusercontent.com/15822070/105508858-7ef68d80-5c92-11eb-8b55-482ae2b711dc.png)

