### PR TITLE
fix: zindex for search bar on headernav style

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
             'https://github.com/carbon-design-system/gatsby-theme-carbon',
           subDirectory: '/packages/example',
         },
+        navigationStyle: 'header',
       },
     },
   ],

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.js
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.js
@@ -44,14 +44,14 @@ const Header = ({ children }) => {
       />
       <Link
         className={cx(styles.headerName, {
-          [styles.collapsed]: searchIsOpen,
+          [styles.open]: searchIsOpen,
           [styles.headerNameWithHeaderNav]: navigationStyle,
         })}
         to="/">
         {children}
       </Link>
       {navigationStyle && <HeaderNav />}
-      <HeaderGlobalBar>
+      <HeaderGlobalBar className={cx({ [styles.searchIsOpen]: searchIsOpen })}>
         {isSearchEnabled && <GlobalSearch />}
         <HeaderGlobalAction
           className={cx(styles.headerButton, styles.switcherButton, {

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.js
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.js
@@ -44,14 +44,15 @@ const Header = ({ children }) => {
       />
       <Link
         className={cx(styles.headerName, {
-          [styles.open]: searchIsOpen,
+          [styles.searchIsOpenOnLink]: searchIsOpen,
           [styles.headerNameWithHeaderNav]: navigationStyle,
         })}
         to="/">
         {children}
       </Link>
       {navigationStyle && <HeaderNav />}
-      <HeaderGlobalBar className={cx({ [styles.searchIsOpen]: searchIsOpen })}>
+      <HeaderGlobalBar
+        className={cx({ [styles.searchIsOpenOnBar]: searchIsOpen })}>
         {isSearchEnabled && <GlobalSearch />}
         <HeaderGlobalAction
           className={cx(styles.headerButton, styles.switcherButton, {

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -12,7 +12,7 @@
   }
 }
 
-.searchIsOpen {
+.searchIsOpenOnBar {
   z-index: 2;
 }
 
@@ -115,7 +115,7 @@ header.header {
   border-top: 1px solid transparent;
   display: flex;
   align-items: center;
-  z-index: 2;
+  z-index: 3;
   &:focus {
     outline: 2px solid $carbon--white-0;
     outline-offset: -2px;
@@ -127,7 +127,7 @@ header.header {
   }
 }
 
-.open {
+.searchIsOpenOnLink {
   z-index: 1;
 }
 

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -5,11 +5,15 @@
   top: 0;
   right: 0;
   width: calc(100% - 3rem);
-  z-index: 2;
+  z-index: 1;
   @include carbon--breakpoint('lg') {
     position: static;
     width: auto;
   }
+}
+
+.searchIsOpen {
+  z-index: 2;
 }
 
 // Overrides upstream Carbon styles for header nav
@@ -20,6 +24,7 @@
     left: 25%;
     top: 0;
     padding-left: 0;
+    z-index: 2;
   }
 }
 
@@ -110,7 +115,7 @@ header.header {
   border-top: 1px solid transparent;
   display: flex;
   align-items: center;
-  z-index: 3;
+  z-index: 2;
   &:focus {
     outline: 2px solid $carbon--white-0;
     outline-offset: -2px;
@@ -122,7 +127,7 @@ header.header {
   }
 }
 
-.collapsed {
+.open {
   z-index: 1;
 }
 

--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -12,6 +12,7 @@
   }
 }
 
+// When search is open, it will properly sit on top of the navigation links when using the headernav style of naviation.
 .searchIsOpenOnBar {
   z-index: 2;
 }
@@ -127,6 +128,7 @@ header.header {
   }
 }
 
+// When search is open this will allow the search bar to cover the header on mobile and tablet screens.
 .searchIsOpenOnLink {
   z-index: 1;
 }


### PR DESCRIPTION
More z-index issues with the header. Theres probably a more elegant way to do this. I feel like i'm playing wack-a-mole where my z-index property is the hammer and the onClick is the mole.

Currently, the nav items in the header nav aren't able to be clicked on because of their z-index. This fixes that by altering the z-index.