### PR TITLE
Fix: update package.json scripts for npm users

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -5,7 +5,7 @@
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",
-    "dev:clean": "yarn clean && yarn dev",
+    "dev:clean": "gatsby clean && gatsby develop -H 0.0.0.0",
     "build": "gatsby build",
     "build:clean": "yarn clean && gatsby build",
     "serve": "gatsby serve",


### PR DESCRIPTION
The script for `dev:clean` is currently `yarn build && yarn clean` or something like this. 

If a user is utilizing `npm` as a package manager instead of yarn, or don't have yarn installed on their machine, they will continue to see error when running `npm run dev:clean`.

#### Changelog

**New**

- Updated `package.json` avail scripts for npm users

**Changed**

- `dev:clean` points to `gatsby clean && gatsby develop -H 0.0.0.0`

**Removed**

- removed `yarn clean && yarn dev` from `dev:clean`
