### PR TITLE
chore(switcher): changing to new url for Carbon for IBM.com

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -102,7 +102,7 @@ const DefaultChildren = () => (
     <SwitcherLink href="https://www.carbondesignsystem.com/">
       Carbon Design System
     </SwitcherLink>
-    <SwitcherLink href="https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/">
+    <SwitcherLink href="https://www.ibm.com/standards/carbon/">
       Carbon for IBM.com
     </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/design/event/">


### PR DESCRIPTION
Closes #

N/A

#### Changelog

**Changed**

- Updated link to Carbon for IBM.com website
