### PR TITLE
ensure the dark scrollbar shows up in the page tabs

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/PageTabs/PageTabs.module.scss
@@ -15,6 +15,7 @@
   padding: 0;
   overflow-x: auto;
   scrollbar-width: none;
+  color-scheme: dark;
 }
 
 .list-item {


### PR DESCRIPTION
if you're on light theme, even though page tabs render as dark, the scrollbar still renders in light

this fixes that

**before**

![image](https://user-images.githubusercontent.com/14989804/127513199-b9f401e3-127f-4385-b3ef-16fe783be12f.png)

**after**

![image](https://user-images.githubusercontent.com/14989804/127513247-ddb483ab-67c8-4e32-aa88-65d2f44273c5.png)
