### PR TITLE
fix(code-module): ensure the scrollbar is dark

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
@@ -33,6 +33,7 @@
   font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono',
     'Bitstream Vera Sans Mono', Courier, monospace;
   color: $carbon--white-0;
+  color-scheme: dark;
   @include carbon--type-style('code-02');
   width: calc(100% + 2rem);
   @include carbon--breakpoint('lg') {


### PR DESCRIPTION
related to #1153 

seems like this component also always renders in dark, so this PR ensures that the dark scrollbar always shows up inside it

**before**

![image](https://user-images.githubusercontent.com/14989804/127518411-cd361a63-b41b-489c-a596-d73c4bc7c241.png)

**after**

![image](https://user-images.githubusercontent.com/14989804/127518511-97e88bf8-08c5-48a9-8822-ab16ea2e0935.png)