### PR TITLE
chore: Fix path in shadowing guide

### DIFF
--- a/packages/example/src/pages/guides/shadowing.mdx
+++ b/packages/example/src/pages/guides/shadowing.mdx
@@ -44,7 +44,7 @@ In order to place your own title in the Header component:
    Everything after `src/gatsby-theme-carbon/` refers to the
    [src directory of gatsby-theme-carbon](https://github.com/carbon-design-system/gatsby-theme-carbon/tree/main/packages/gatsby-theme-carbon/src).
 
-1. Create a file inside of the directory that matches the component you want to shadow. For example: `src/gatsby-theme-carbon/Header/index.js`. _If shadowing Footer or Header the file must be named **`index.js`**_
+1. Create a file inside of the directory that matches the component you want to shadow. For example: `src/gatsby-theme-carbon/components/Header/index.js`. _If shadowing Footer or Header the file must be named **`index.js`**_
 
 1. Import the component you wish to shadow by providing the full url pointing at
    the component within the theme


### PR DESCRIPTION
The example path in the shadowing guide is incorrect. It does not match the component directories.

For reference this is the path to Header's index.js: https://github.com/carbon-design-system/gatsby-theme-carbon/blob/main/packages/gatsby-theme-carbon/src/components/Header/index.js

#### Changelog

**Changed**

Path has been updated to match the component directories.
