### PR TITLE
feat(minicard): support transferring props to Gatsby Links and anchors

### DIFF
--- a/packages/example/src/pages/components/MiniCard.mdx
+++ b/packages/example/src/pages/components/MiniCard.mdx
@@ -10,14 +10,12 @@ description:
 
 <PageDescription>
 
-
 The `<MiniCard>` component can be used in place of a `<ResourceCard>` if your
 content allows it. Unless it is sitting aside your main conent, it should always
 be wrapped inside of a `<CardGroup>`. This allows the correct gutter and border
 placement between a group of cards.
 
 </PageDescription>
-
 
 <InlineNotification>
   Although the mini-resource card has a similar geometry to the button
@@ -33,15 +31,12 @@ placement between a group of cards.
 
 <CardGroup>
 
-
 <MiniCard title="26 characters per MiniCard" href="/demo">
-
 
 ![Adobe Acrobat icon](/images/adobe-icon.svg)
 
 </MiniCard>
 <MiniCard title="Use the default icon" href="/demo" />
-
 
 <MiniCard
   title="Choose from other icons"
@@ -51,20 +46,16 @@ placement between a group of cards.
 
 <MiniCard title="Or bring your own" href="/demo">
 
-
 ![Github icon](/images/sketch-icon.png)
 
 </MiniCard>
 
-
 </CardGroup>
-
 
 <Title>Aside</Title>
 
 <Row>
 <Column colLg={8}>
-
 
 When you have the mini resource card sitting aside the main content, be sure to
 add the `gutterLg`, properties to the `<MiniCard>`. This will ensure the
@@ -77,12 +68,10 @@ MiniCard has the appropriate gutters at the approriate breakpoints.
   href="https://gatsby-theme-carbon.now.sh"
   >
 
-
 ![Sketch icon](/images/sketch-icon.png)
 
 </MiniCard>
 </Row>
-
 
 ## Code
 
@@ -111,7 +100,6 @@ MiniCard has the appropriate gutters at the approriate breakpoints.
 <Row>
 <Column colLg={8}>
 
-
 When you have the mini resource card sitting aside the main content, be sure to
 add the `gutterLg`, properties to the `<MiniCard>`. This will ensure the
 MiniCard has the appropriate gutters at the approriate breakpoints.
@@ -123,12 +111,10 @@ MiniCard has the appropriate gutters at the approriate breakpoints.
   href="https://gatsby-theme-carbon.now.sh"
   >
 
-
 ![Sketch icon](/images/sketch-icon.png)
 
 </MiniCard>
 </Row>
-
 ```
 
 ### Props

--- a/packages/example/src/pages/components/MiniCard.mdx
+++ b/packages/example/src/pages/components/MiniCard.mdx
@@ -11,9 +11,9 @@ description:
 <PageDescription>
 
 The `<MiniCard>` component can be used in place of a `<ResourceCard>` if your
-content allows it. Unless it is sitting aside your main conent, it should always
-be wrapped inside of a `<CardGroup>`. This allows the correct gutter and border
-placement between a group of cards.
+content allows it. Unless it is sitting beside your main content, it should
+always be wrapped inside of a `<CardGroup>`. This allows the correct gutter and
+border placement between a group of cards.
 
 </PageDescription>
 

--- a/packages/gatsby-theme-carbon/src/components/MiniCard/MiniCard.js
+++ b/packages/gatsby-theme-carbon/src/components/MiniCard/MiniCard.js
@@ -36,6 +36,7 @@ const MiniCard = ({
   title,
   actionIcon,
   className,
+  linkProps,
   ...rest
 }) => {
   const cardContent = (
@@ -57,11 +58,11 @@ const MiniCard = ({
   }
 
   const cardContainer = isLink ? (
-    <Link to={href} className={`${prefix}--tile--clickable`}>
+    <Link to={href} className={`${prefix}--tile--clickable`} {...linkProps}>
       {cardContent}
     </Link>
   ) : (
-    <a href={href} className={`${prefix}--tile--clickable`}>
+    <a href={href} className={`${prefix}--tile--clickable`} {...linkProps}>
       {cardContent}
     </a>
   );


### PR DESCRIPTION
Closes #1159

This PR adds support for transferring props to Gatsby Links and anchors in the MiniCard component via the `linkProps` prop

#### Changelog

**New**

- `linkProps` prop on `<MiniCard />`

**Changed**

- typo in MiniCard docs