### PR TITLE
fix: changes theme_color to gray 100

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
         short_name: 'Gatsby Theme Carbon',
         start_url: '/',
         background_color: '#ffffff',
-        theme_color: '#0062ff',
+        theme_color: '#161616',
         display: 'browser',
       },
     },


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- changes theme_color to gray 100 / #161616. [theme_color](https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color) is used to tint the title bar in [Safari 15](https://css-tricks.com/safari-15-new-ui-theme-colors-and-a-css-tricks-cameo/) and [Android Chrome](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color)

Before:
![image (30)](https://user-images.githubusercontent.com/2853295/134677602-703f9f32-1aeb-4913-9714-958487d12e1c.png)


After:
![image (31)](https://user-images.githubusercontent.com/2853295/134677618-482a2a62-3405-43a1-8e15-ade8fcb37162.png)

**Removed**

- {{removed thing}}
