### PR TITLE
fix: update grid padding at large breakpoint

### DIFF
--- a/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_page.scss
@@ -13,7 +13,7 @@
 
   @include carbon--breakpoint('lg') {
     padding-left: calc(
-      25% + 2rem
+      25% + 1.5rem
     ); //2rem to account for 2rem left padding default on grid
     padding-right: 2rem;
   }


### PR DESCRIPTION
Grid devtools overlay was 8px "off" at large breakpoint. 

### Before / wrong
![image](https://user-images.githubusercontent.com/2753488/135336197-1fc471c0-a2b1-45ae-904d-618d6b3fee74.png)


### Review

Ensure text/components match up with grid overlay at large breakpoint