### PR TITLE
fix: switcher button focus state

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Header/Header.module.scss
@@ -138,35 +138,12 @@ header.header {
   transition: background-color $duration--fast-02 $carbon--standard-easing;
 }
 
-// Switcher button, extra specificity to override Carbon styles
+// Switcher button, extra specificity to override Carbon tooltip button styles
 // Hex values used pending shell theming
-.header .header-button.switcher-button {
-  background-color: $carbon--gray-100;
-  position: relative;
-  border: none;
-  border-color: $ui-05;
-  border-bottom: 1px solid $carbon--gray-80;
+.header :global(.bx--tooltip__trigger).header-button.switcher-button {
   &:focus {
-    outline: 2px solid $carbon--white-0;
-    outline-offset: -2px;
-  }
-  &:hover {
-    background-color: $carbon--gray-80;
-  }
-  &:active {
-    background-color: #3d3d3d;
-    border-left: 1px solid $ui-05;
-    border-right: 1px solid $ui-05;
-  }
-}
-
-.header-button.switcher-button.switcher-button--open {
-  border: 1px solid transparent;
-  border-left: 1px solid $carbon--gray-80;
-  border-bottom: 1px solid $carbon--gray-100;
-  background-color: $carbon--gray-100;
-  &:active {
-    border-left: 1px solid $carbon--white-0;
+    box-shadow: none;
+    border-color: $carbon--white-0;
   }
 }
 


### PR DESCRIPTION
Closes #1168 

Switcher focus state was pulling in styles from the Carbon tooltip.

#### Changelog

**New**

- Updated style override for Carbon button tooltip

**Removed**

- Old switcher style overrides no longer needed
