### PR TITLE
fix: line length for lists and headings

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
@@ -44,15 +44,14 @@
 .h3,
 .h4,
 .h5,
-.h6,
-.list {
-  padding-right: 0;
+.h6 {
+  padding-right: $spacing-05;
   margin-right: 0;
   margin-left: 0;
 
   @include carbon--breakpoint('md') {
-    width: 100%;
-    padding-right: 0;
+    width: 75%;
+    padding-right: $spacing-07;
     margin-right: 0;
     margin-left: 0;
   }
@@ -64,6 +63,23 @@
 
 .h4 + * {
   --space: 0;
+}
+
+.list {
+  padding-right: $spacing-05;
+  margin-right: 0;
+  margin-left: 0;
+
+  @include carbon--breakpoint('md') {
+    width: 100%;
+    padding-right: $spacing-07;
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  @include carbon--breakpoint('lg') {
+    width: 66.667%;
+  }
 }
 
 //spacing exception for nested list items


### PR DESCRIPTION
Closes #1156 

Adds correct right padding to lists and headings

#### Test

Make sure nothing with lists or headings in markdown are broken

(screen shot from local with longer headings)
![Screen Shot 2021-10-05 at 2 04 14 PM](https://user-images.githubusercontent.com/2753488/136086950-03e60971-6fbf-40c4-a04c-63407b7c90f1.png)

