### PR TITLE
docs: advice about the content for this component

### DIFF
--- a/packages/example/src/pages/components/PageDescription.mdx
+++ b/packages/example/src/pages/components/PageDescription.mdx
@@ -18,7 +18,8 @@ For most pages, we recommend starting with a `PageDescription` followed by
 `AnchorLinks` if the content is long enough. Please note that this component,
 like all MDX components, is picky about white space, the line break above and
 below your content is required, and if you even have an extra space on the empty
-lines above/below it won’t render correctly.
+lines above/below it won’t render correctly. The text for the pages description
+should be consice – one sentence, or maybe two short ones at most.
 
 ## Code
 


### PR DESCRIPTION
I've seen people trying to put too much into the page description. I think it is a sane content guidance to limit the text to one or two short sentences.

#### Changelog

**Changed**

- Notes for the PageDescription component

#### Notes
As documented in #1194, I couldn't run `yarn ci-check` to check this change, but I ran `yarn && yarn build` instead.