### PR TITLE
fix: update the references to the new homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The Gatsby Carbon theme includes all the configuration you need to build a beaut
 ## Resources
 
 - [Contribution guidelines](.github/CONTRIBUTING.md)
-- [Getting Started](https://gatsby-theme-carbon.now.sh/getting-started)
-- [Guides](https://gatsby-theme-carbon.now.sh/guides/configuration)
-- [Components](https://gatsby-theme-carbon.now.sh/components/markdown)
-- [Demo](https://gatsby-theme-carbon.now.sh/demo)
-- [Gallery](https://gatsby-theme-carbon.now.sh/gallery)
+- [Getting Started](https://gatsby.carbondesignsystem.com/getting-started)
+- [Guides](https://gatsby.carbondesignsystem.com/guides/configuration)
+- [Components](https://gatsby.carbondesignsystem.com/components/markdown)
+- [Demo](https://gatsby.carbondesignsystem.com/demo)
+- [Gallery](https://gatsby.carbondesignsystem.com/gallery)

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -12,7 +12,7 @@
 ## How do I use it?
 
 Check out our quick
-[getting started](https://gatsby-theme-carbon.now.sh/getting-started) guide and
+[getting started](https://gatsby.carbondesignsystem.com/getting-started) guide and
 video!
 
 `gatsby-theme-carbon` at it’s core relies on [mdx](https://mdxjs.com/) for page
@@ -28,4 +28,4 @@ You’re also free to make your own components and use them in your MDX pages.
 
 ## What’s Next?
 
-[Check out the docs!](https://gatsby-theme-carbon.now.sh)
+[Check out the docs!](https://gatsby.carbondesignsystem.com)

--- a/packages/example/src/pages/components/ImageGallery.mdx
+++ b/packages/example/src/pages/components/ImageGallery.mdx
@@ -98,7 +98,7 @@ the small breakpoint is not defined.
 Here’s an example of how to use the ImageGallery and the ImageGalleryImage
 components in markdown.
 
-```mdx path=/components/ImageGallery.mdx src=https://gatsby-theme-carbon.now.sh
+```mdx path=/components/ImageGallery.mdx src=https://gatsby.carbondesignsystem.com
 <ImageGallery>
 <ImageGalleryImage alt="IBM Design" title="IBM Design" col={4}>
 

--- a/packages/example/src/pages/components/MiniCard.mdx
+++ b/packages/example/src/pages/components/MiniCard.mdx
@@ -62,10 +62,10 @@ add the `gutterLg`, properties to the `<MiniCard>`. This will ensure the
 MiniCard has the appropriate gutters at the approriate breakpoints.
 
 </Column>
-<MiniCard 
+<MiniCard
   gutterLg
   title="By itself, as an Aside"
-  href="https://gatsby-theme-carbon.now.sh"
+  href="https://gatsby.carbondesignsystem.com"
   >
 
 ![Sketch icon](/images/sketch-icon.png)
@@ -108,7 +108,7 @@ MiniCard has the appropriate gutters at the approriate breakpoints.
 <MiniCard
   gutterLg
   title="By itself, as an Aside"
-  href="https://gatsby-theme-carbon.now.sh"
+  href="https://gatsby.carbondesignsystem.com"
   >
 
 ![Sketch icon](/images/sketch-icon.png)

--- a/packages/example/src/pages/components/ResourceCard.mdx
+++ b/packages/example/src/pages/components/ResourceCard.mdx
@@ -22,7 +22,7 @@ placement between a group of cards.
       title="Title"
       aspectRatio="2:1"
       actionIcon="arrowRight"
-      href="https://gatsby-theme-carbon.now.sh"
+      href="https://gatsby.carbondesignsystem.com"
       >
 
 
@@ -35,7 +35,7 @@ placement between a group of cards.
       subTitle="Only subtitle"
       actionIcon="download"
       aspectRatio="2:1"
-      href="https://gatsby-theme-carbon.now.sh"
+      href="https://gatsby.carbondesignsystem.com"
       >
 
 
@@ -50,7 +50,7 @@ placement between a group of cards.
       aspectRatio="2:1"
       color="dark"
       actionIcon="email"
-      href="https://gatsby-theme-carbon.now.sh"
+      href="https://gatsby.carbondesignsystem.com"
       >
 
 
@@ -63,7 +63,7 @@ placement between a group of cards.
       title="Disabled card"
       aspectRatio="2:1"
       disabled
-      href="https://gatsby-theme-carbon.now.sh"
+      href="https://gatsby.carbondesignsystem.com"
       >
 
 
@@ -115,7 +115,7 @@ placement between a group of cards.
     title="Title"
     aspectRatio="2:1"
     actionIcon="arrowRight"
-    href="https://gatsby-theme-carbon.now.sh">
+    href="https://gatsby.carbondesignsystem.com">
 
 
 ![Adobe Acrobat icon](/images/adobe-icon.svg)
@@ -133,7 +133,7 @@ placement between a group of cards.
     subTitle="Only subtitle"
     actionIcon="download"
     aspectRatio="2:1"
-    href="https://gatsby-theme-carbon.now.sh">
+    href="https://gatsby.carbondesignsystem.com">
 
 
 ![Mural icon](/images/mural-icon.png)
@@ -153,7 +153,7 @@ placement between a group of cards.
     aspectRatio="2:1"
     color="dark"
     actionIcon="email"
-    href="https://gatsby-theme-carbon.now.sh">
+    href="https://gatsby.carbondesignsystem.com">
 
 
 ![Sketch icon](/images/sketch-icon.png)
@@ -171,7 +171,7 @@ placement between a group of cards.
     title="Disabled card"
     aspectRatio="2:1"
     disabled
-    href="https://gatsby-theme-carbon.now.sh"
+    href="https://gatsby.carbondesignsystem.com"
   />
 </Column>
 ```

--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -15,7 +15,7 @@ highlighting as well as optional `path` and `src` features.
 
 <Title>Horizontal overflow</Title>
 
-```markdown path=/directory/file.mdx src=https://gatsby-theme-carbon.now.sh
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
 ## Path and src w/ overflow
 
 This example overflows to demonstrate the text fading out under the side bar.
@@ -26,7 +26,7 @@ This example overflows to demonstrate the text fading out under the side bar.
 
 <Title>Vertical overflow</Title>
 
-```markdown path=/directory/file.mdx src=https://gatsby-theme-carbon.now.sh
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
 ## Path and src w/ overflow
 
 This example demonstrates the show more button. This example demonstrates the
@@ -42,7 +42,7 @@ button. This example demonstrates the show more button.
 ## Code
 
 ````
-```markdown path=/directory/file.mdx src=https://gatsby-theme-carbon.now.sh
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
 ### Path and src
 
 This code snippet provides both a `path` and a `src`.

--- a/packages/example/src/pages/contributions.mdx
+++ b/packages/example/src/pages/contributions.mdx
@@ -63,7 +63,7 @@ This project has two packages: the actual theme package (`gatsby-theme-carbon`)
 and the `example` package. The example package emulates a project which uses the
 theme. Its only dependencies are Gatsby, React, and the adjacent theme package.
 The `example` package also serves as the theme’s documentation and
-[website](https://gatsby-theme-carbon.now.sh); it’s deployed on every merge to
+[website](https://gatsby.carbondesignsystem.com); it’s deployed on every merge to
 main.
 
 New theme development will happen in the theme package while documentation and

--- a/packages/gatsby-theme-carbon/gatsby-ssr.js
+++ b/packages/gatsby-theme-carbon/gatsby-ssr.js
@@ -32,7 +32,7 @@ export const onRenderBody = ({ setHeadComponents, setBodyAttributes }) => {
     <link
       key="sans"
       rel="preload"
-      href="https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatin-VF.woff2"
+      href="https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatin-VF.woff2"
       as="font"
       type="font/woff2"
       crossOrigin=""

--- a/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
@@ -7,9 +7,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+0020-00FF;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatin-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatin-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatin-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatin-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: normal;
@@ -19,9 +19,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+0100-1EF9;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatinExt-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatinExt-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatinExt-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatinExt-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: normal;
@@ -31,9 +31,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+2000-FB02;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansOther-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansOther-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansOther-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansOther-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: normal;
@@ -44,9 +44,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+0020-00FF;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatin-Italic-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatin-Italic-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatin-Italic-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatin-Italic-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: italic;
@@ -56,9 +56,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+0100-1EF9;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatinExt-Italic-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatinExt-Italic-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansLatinExt-Italic-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansLatinExt-Italic-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: italic;
@@ -68,9 +68,9 @@
   font-family: 'IBM Plex Sans VF';
   unicode-range: U+2000-FB02;
   font-display: swap;
-  src: url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansOther-Italic-VF.woff2')
+  src: url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansOther-Italic-VF.woff2')
       format('woff2-variations'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/IBMPlexSansOther-Italic-VF.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/IBMPlexSansOther-Italic-VF.woff2')
       format('woff2');
   font-weight: 100 900;
   font-style: italic;
@@ -82,7 +82,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/mono/IBMPlexMono-Regular-Latin1.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin1.woff2')
       format('woff2');
   unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131,
     U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E,
@@ -95,7 +95,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/mono/IBMPlexMono-Regular-Latin2.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF,
     U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02;
@@ -106,7 +106,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/mono/IBMPlexMono-Regular-Latin3.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
@@ -116,7 +116,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/mono/IBMPlexMono-Regular-Pi.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Pi.woff2')
       format('woff2');
   unicode-range: U+0E3F, U+2032-2033, U+2070, U+2075-2079, U+2080-2081, U+2083,
     U+2085-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E,
@@ -131,7 +131,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-    url('https://gatsby-theme-carbon.now.sh/fonts/mono/IBMPlexMono-Regular-Cyrillic.woff2')
+    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Cyrillic.woff2')
       format('woff2');
   unicode-range: U+0400-045F, U+0472-0473, U+0490-049D, U+04A0-04A5, U+04AA-04AB,
     U+04AE-04B3, U+04B6-04BB, U+04C0-04C2, U+04CF-04D9, U+04DC-04DF, U+04E2-04E9,
@@ -160,7 +160,7 @@ body {
 }
 
 @supports (font-variation-settings: normal) {
-  // This rule includes both html and body to outgun the carbon--type-reset mixin 
+  // This rule includes both html and body to outgun the carbon--type-reset mixin
   // carbon--type-reset is being called inadvertantly when sites invoke the carbon--type-style mixin
   // Without it both html and body, the font-family gets overridden with `IBM Plex Sans` (not the variable font)
   html body {


### PR DESCRIPTION
I found out late last year that most of the URLs in the code base still referenced the old homepage [https://gatsby-theme-carbon.now.sh](https://gatsby-theme-carbon.now.sh). The current and long-term URL is now [https://gatsby.carbondesignsystem.com/](https://gatsby.carbondesignsystem.com/), so I'm updating all references to the new URL. One of the advantages of that fix is that, as the fonts are loaded over the host too, the font loading will be faster as the redirect from `gatsby-theme-carbon.now.sh` to `gatsby-theme-carbon.vercel.app` will be avoided.

#### Changelog

**Changed**

- References to the old URL.
