### PR TITLE
feat: new config option to add default mdx layouts

### DIFF
--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -377,3 +377,23 @@ array in the theme options.
     },
   ],
 ```
+
+## Adding new MDX layouts 
+
+`gatsby-plugin-mdx` and `gatsby-source-filesystem` can work together to automatically template MDX files in a given directory. See the [plugin documentation](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#default-layouts).
+
+The Carbon theme already comes with a default layout, but you can add your own with the `extraLayouts` option.
+
+```js
+ plugins: [
+    {
+      resolve: 'gatsby-theme-carbon',
+      options: {
+        extraLayouts: {
+          posts: require.resolve('./src/layouts/postLayout.js')
+        }
+      },
+ ],
+```
+
+Note that the extra layouts do not inherit from theme default. Custom layouts start from a clean slate. If you want to iterate on the Carbon template, copy `/gatsby-theme-carbon/src/templates/Default.js` to your custom template as a starting point. When doing this, you may also need to change the import paths to the correct location.

--- a/packages/gatsby-theme-carbon/gatsby-config.js
+++ b/packages/gatsby-theme-carbon/gatsby-config.js
@@ -34,6 +34,7 @@ module.exports = (themeOptions) => {
     gatsbyPluginSharpOptions = {},
     isServiceWorkerEnabled = false,
     isSwitcherEnabled = true,
+    extraLayouts = {},
   } = themeOptions;
 
   const theme = { ...defaultTheme, ...themeOption };
@@ -121,6 +122,7 @@ module.exports = (themeOptions) => {
           defaultLayouts: {
             default: require.resolve('./src/templates/Default.js'),
             home: require.resolve('./src/templates/Homepage.js'),
+            ...extraLayouts,
           },
         },
       },


### PR DESCRIPTION
Adds a new configuration option that allows user to include additional `gatsby-plugin-mdx` layouts.

#### Changelog

**New**

- A new extraLayouts option is added to the theme's `gatsby-config.js`. It defaults to an empty object.

#### Usage

In a project using `gatsby-theme-carbon`, the user can add their own `gatsby-plugin-mdx` layout like so:

```
  {
      resolve: 'gatsby-theme-carbon',
      options: {
        navigationStyle: 'header',
        mediumAccount: 'carbondesign',
        isSwitcherEnabled: false,
        titleType: 'prepend',
        extraLayouts: {
          posts: require.resolve('./src/layouts/postLayout.js')
        },
...
```

where `posts` is defined in the same file with `gatsby-source-filesystem`.
