### PR TITLE
fix(link): correct link to Cirrus getting started

### DIFF
--- a/packages/example/src/pages/guides/hosting.mdx
+++ b/packages/example/src/pages/guides/hosting.mdx
@@ -33,7 +33,7 @@ others have found helpful for hosting.
 Built on Redhat OpenShift, this is the CIO-preferred solution for internally
 hosted applications and is provided to all IBMers.
 
-[Get started](https://w3.ibm.com/w3publisher/cio-cirrus-platform)
+[Get started](https://w3.ibm.com/w3publisher/cio-hybrid-cloud-services/get-started)
 
 ### Examples
 


### PR DESCRIPTION
Corrects the getting started link here: https://gatsby-theme-carbon.vercel.app/guides/hosting#cirrus