### PR TITLE
fix(expressive-list-container): remove margin-top from first content element

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/ExpressiveListContainer/ExpressiveListContainer.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/ExpressiveListContainer/ExpressiveListContainer.module.scss
@@ -33,3 +33,8 @@
 .text {
   padding-right: 2rem;
 }
+
+.text > *:first-child,
+.text:empty + *:nth-child(2) {
+  margin-top: 0;
+}


### PR DESCRIPTION
Closes #1239

Sets `margin-top` to `0` for the first child of `.ExpressiveListContainer--text` and for the first adjacent element if `.ExpressiveListContainer--text` is empty (no `props.text` used, only `props.children`). The second rule makes sure that for example the video container on the documentation site is top-aligned when no text is used (example 2) but it keeps its top spacing when the text is populated (example 1).

#### Changelog

**New**

- CSS rule for above logic in `ExpressiveListContainer.module.scss`