### PR TITLE
fix(markdown): ensure links within lists do not have padding

### DIFF
--- a/packages/example/src/pages/demo/index.mdx
+++ b/packages/example/src/pages/demo/index.mdx
@@ -5,13 +5,11 @@ description: Demonstration of some of the theme components in action.
 
 <PageDescription>
 
-
 This page is meant to demonstrate some of the components in action. You can
 check out the markdown used for this page
 [on github](https://github.com/carbon-design-system/gatsby-theme-carbon/blob/main/packages/example/src/pages/demo/index.mdx).
 
 </PageDescription>
-
 
 <AnchorLinks>
   <AnchorLink>Building bonds</AnchorLink>
@@ -28,7 +26,6 @@ check out the markdown used for this page
   actionIcon="arrowRight"
 >
 
-
 ![Dark article layout mockup](/images/Article_06.png)
 
 </ArticleCard>
@@ -39,7 +36,6 @@ check out the markdown used for this page
   href="/guides/configuration"
   actionIcon="arrowRight"
 >
-
 
 ![Dark article layout mockup](/images/Article_06.png)
 
@@ -52,16 +48,13 @@ check out the markdown used for this page
   actionIcon="arrowRight"
 >
 
-
 ![Dark article layout mockup](/images/Article_06.png)
 
 </ArticleCard>
 </Column>
 </Row>
 
-
 <PageDescription>
-
 
 Prow scuttle parrel provost Sail ho shrouds spirits boom mizzenmast yardarm.
 Pinnace holystone mizzenmast quarter crow’s nest nipperkin grog yardarm hempen
@@ -70,7 +63,6 @@ gangway rutters.
 
 </PageDescription>
 
-
 Prow scuttle parrel provost Sail ho shrouds spirits boom mizzenmast yardarm.
 Pinnace holystone mizzenmast quarter crow’s nest nipperkin grog yardarm hempen
 halter furl. Swab barque interloper chantey doubloon starboard grog black jack
@@ -78,7 +70,6 @@ gangway rutters.
 
 <Row>
 <Column colMd={5} colLg={8}>
-
 
 ## Section heading
 
@@ -97,7 +88,6 @@ can improve business, society and the human condition.
 <Column colMd={2} colLg={3} offsetMd={1} offsetLg={1}>
 <Aside>
 
-
 <p>
   <strong>
     Good design is always
@@ -112,7 +102,6 @@ stylistic terms, but the modernist attitudes and approach used at the time.
 </Aside>
 </Column>
 </Row>
-
 
 ## Small anchor links
 
@@ -149,7 +138,9 @@ gangway rutters.
 
 - This is a demonstration of an unordered list item. This list item is
   particularly long to demonstrate how the text wraps and aligns with the first
-  line.
+  line. With `a code snippet` and `yet another code snippet` and also then
+  [a link as well](http://carbondesignsystem.com/). This is also a
+  [a second link](http://carbondesignsystem.com/).
   - This is a nested list item, it should wrap in the same way. Typically,
     nested list items should be of the same type (ordered, unordered) as their
     parent.

--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -62,7 +62,7 @@
     "react-transition-group": "^4.4.2",
     "react-use": "^15.3.4",
     "remark-slug": "^6.0.0",
-    "sass": "^1.49.0",
+    "sass": "^1.52.3",
     "slugify": "^1.3.4",
     "smooth-scroll": "^16.1.3",
     "use-media": "^1.4.0"

--- a/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
@@ -144,7 +144,7 @@ ul :global(.cds--list--unordered) {
 }
 
 //spacing for content within list item
-.list-item > * + *:not(:global(.bx--link)) {
+.list-item > * + *:not(:global(.cds--link)) {
   margin-top: var(--space);
 
   &:last-child {

--- a/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/markdown/Markdown.module.scss
@@ -144,7 +144,7 @@ ul :global(.cds--list--unordered) {
 }
 
 //spacing for content within list item
-.list-item > * + * {
+.list-item > * + *:not(:global(.bx--link)) {
   margin-top: var(--space);
 
   &:last-child {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11045,9 +11045,9 @@ immer@8.0.1:
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 immutable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
-  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
 import-cwd@3.0.0:
   version "3.0.0"
@@ -16475,10 +16475,10 @@ sass-resources-loader@^1.3.3:
     glob "^7.1.1"
     loader-utils "^1.0.4"
 
-sass@^1.49.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.49.0.tgz#65ec1b1d9a6bc1bae8d2c9d4b392c13f5d32c078"
-  integrity sha512-TVwVdNDj6p6b4QymJtNtRS2YtLJ/CqZriGg0eIAbAKMlN8Xy6kbv33FsEZSF7FufFFM705SQviHjjThfaQ4VNw==
+sass@^1.52.3:
+  version "1.52.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.3.tgz#b7cc7ffea2341ccc9a0c4fd372bf1b3f9be1b6cb"
+  integrity sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
This fixes the bug blocking https://github.com/carbon-design-system/carbon-website/pull/2975

#### Changelog

**Changed**

- Ensures that links placed as the second/third/fourth/etc sibling within a list item don't have unnecessary padding.
- Update sass version
- Formatting within the demo page

**Removed**

Demo page list section should render the new demo text with no extra vertical padding around links
