### PR TITLE
fix(minicard): export from root index.js

### DIFF
--- a/packages/gatsby-theme-carbon/index.js
+++ b/packages/gatsby-theme-carbon/index.js
@@ -20,3 +20,4 @@ export { default as ExpressiveListContainer } from './src/components/ExpressiveL
 export { default as ExpressiveList } from './src/components/ExpressiveList';
 // Homepage Template Components
 export { HomepageCallout, HomepageBanner } from './src/components/Homepage';
+export { MiniCard } from './src/components/MiniCard';


### PR DESCRIPTION
Adds MiniCard to be exported at the root. We had a report that 
```js
import { MiniCard } from "gatsby-theme-carbon";
``` 

was not working. Until this is published, workaround is 

```js
import { MiniCard } from "gatsby-theme-carbon/src/components/MiniCard";
```

#### Changelog

**New**

- add MiniCard export to index.js