### PR TITLE
chore(resoruces): add new layout module

### DIFF
--- a/packages/gatsby-theme-carbon/src/styles/internal/resources.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/resources.scss
@@ -14,3 +14,4 @@
 // @use '@carbon/react/scss/compat/theme' as *;
 @use '@carbon/react/scss/breakpoint' as *;
 @use '@carbon/react/scss/spacing' as *;
+@use '@carbon/react/scss/layout' as *;


### PR DESCRIPTION
After updating to `@carbon/react@1.31.3` on the Carbon website, getting errors regarding the new `layout` partial

![image](https://github.com/carbon-design-system/gatsby-theme-carbon/assets/11928039/d26f5619-aa5d-4692-af9e-985d648286e4)


