### PR TITLE
Fix: code blocks in mdx + issues/868

### DIFF
--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -7,7 +7,7 @@ description: Usage instructions for the Code blocks component
 
 When authoring markdown using the Carbon Gatsby theme, code blocks have some
 extra super powers you can take advantage of. We provide carbon-themed syntax
-highlighting as well as optional `path` and `src` features.
+highlighting as well as optional `path`, `src` and `hideCode` features.
 
 </PageDescription>
 
@@ -26,8 +26,8 @@ This example overflows to demonstrate the text fading out under the side bar.
 
 <Title>Vertical overflow</Title>
 
-```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
-## Path and src w/ overflow
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com hideCode=true
+## Path, src, hideCode w/ overflow
 
 This example demonstrates the show more button. This example demonstrates the
 show more button. This example demonstrates the show more button. This example
@@ -36,7 +36,9 @@ button. This example demonstrates the show more button. This example
 demonstrates the show more button. This example demonstrates the show more
 button. This example demonstrates the show more button. This example
 demonstrates the show more button. This example demonstrates the show more
-button. This example demonstrates the show more button.
+button. This example demonstrates the show more button. This example demonstrates the show more button. 
+This example demonstrates the show more button. This example demonstrates the show more button. 
+This example demonstrates the show more button. This example demonstrates the show more button. 
 ```
 
 ## Code
@@ -56,3 +58,4 @@ This code snippet provides both a `path` and a `src`.
 | language | string   | [Available languages.](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js) |
 | src      | string   | The full url of a relevant link (source)                                                                                    |
 | path     | string   | A string indicating the filename or path. Due to markdown limitations this can only be a single word                        |
+| hideCode     | boolean   | A boolean indicating if the code block should have a Show More button. Code block should have more than 9 lines to display the button. Default value = `false`|

--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -44,10 +44,10 @@ This example demonstrates the show more button. This example demonstrates the sh
 ## Code
 
 ````mdx
-```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
-### Path and src
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com hideCode=true
 
-This code snippet provides both a `path` and a `src`.
+### Path, src and hideCode
+This code snippet provides a `path`, a `src` and `hideCode` prop. 
 ```
 ````
 

--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -41,7 +41,7 @@ button. This example demonstrates the show more button.
 
 ## Code
 
-````
+````mdx
 ```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
 ### Path and src
 

--- a/packages/example/src/pages/guides/configuration.mdx
+++ b/packages/example/src/pages/guides/configuration.mdx
@@ -298,7 +298,7 @@ work, you can try calling the (underlying) remark plugin directly using the
 
 For the below markdown snippet:
 
-````
+````mdx
 ```mermaid
 graph LR
 install[Install Plugin]
@@ -346,7 +346,7 @@ project:
 
 For the below markdown snippet:
 
-```
+```mdx
 +-------+----------+------+
 | Table Headings   | Here |
 +-------+----------+------+

--- a/packages/gatsby-theme-carbon/gatsby-config.mjs
+++ b/packages/gatsby-theme-carbon/gatsby-config.mjs
@@ -9,6 +9,16 @@ import remarkGfm from 'remark-gfm';
 import { fileURLToPath } from 'url';
 import defaultLunrOptions from './config/lunr-options.mjs';
 
+/*
+  This is a rehype plugin that adds support for metadata to the fenced code block
+  For eg: 
+  ```jsx path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
+  const a = 10;
+  ```
+  A metaData prop of format path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com is added to the code block
+*/
+import rehypeAddCodeMetaData from 'rehype-mdx-fenced-code-meta-support';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const carbonThemes = {
   white: './src/styles/internal/white.scss',
@@ -119,6 +129,7 @@ export default (themeOptions) => {
           ],
           mdxOptions: {
             remarkPlugins: [remarkGfm, ...remarkPlugins],
+            rehypePlugins: [rehypeAddCodeMetaData],
           },
           // defaultLayouts: {
           //   default: require.resolve('./src/templates/Default.js'),

--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -62,7 +62,7 @@
     "react-helmet": "^6.1.0",
     "react-transition-group": "^4.4.5",
     "react-use": "^17.5.0",
-    "rehype-mdx-fenced-code-meta-support": "^1.0.0",
+    "rehype-mdx-fenced-code-meta-support": "^1.0.4",
     "remark-gfm": "3.0.1",
     "sass": "^1.71.1",
     "slugify": "^1.6.6",

--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -62,6 +62,7 @@
     "react-helmet": "^6.1.0",
     "react-transition-group": "^4.4.5",
     "react-use": "^17.5.0",
+    "rehype-mdx-fenced-code-meta-support": "^1.0.0",
     "remark-gfm": "3.0.1",
     "sass": "^1.71.1",
     "slugify": "^1.6.6",

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Highlight, defaultProps } from 'prism-react-renderer';
+import { Highlight } from 'prism-react-renderer';
 import { ChevronDown, ChevronUp } from '@carbon/react/icons';
 
 import cx from 'classnames';
@@ -26,31 +26,28 @@ const Code = ({ children, className: classNameProp = '', path, src }) => {
   }, [classNameProp]);
 
   const { interiorTheme } = useMetadata();
-
   const language = classNameProp.replace(/language-/, '').replace('mdx', 'jsx');
 
   const removeTrailingEmptyLine = (lines) => {
-    if (lines && lines.length) {
-      const [lastLine] = lines.splice(-1);
-      if (lastLine[0].empty) {
-        return lines;
-      }
-      return [...lines, lastLine];
+    const [lastLine] = lines[lines.length - 1];
+
+    // empty is a boolean property coming inside the lastLine object
+    if (lastLine.empty) {
+      lines.splice(-1);
+      return lines;
     }
+    return [...lines];
   };
 
   const getLines = (lines) => {
-    const withoutTrailingEmpty = removeTrailingEmptyLine(lines);
-
-    if (withoutTrailingEmpty && withoutTrailingEmpty.length > 9) {
+    const withoutTrailingEmptyLines = removeTrailingEmptyLine(lines);
+    if (withoutTrailingEmptyLines && withoutTrailingEmptyLines.length > 9) {
       setHasMoreThanNineLines(true);
     }
-
     if (shouldShowMore) {
-      return withoutTrailingEmpty;
+      return withoutTrailingEmptyLines;
     }
-
-    return withoutTrailingEmpty ? withoutTrailingEmpty.slice(0, 9) : [];
+    return withoutTrailingEmptyLines.slice(0, 9);
   };
 
   // TODO - remove this once we have a better way of handling inline code. This seems like a hack
@@ -64,7 +61,6 @@ const Code = ({ children, className: classNameProp = '', path, src }) => {
         {children}
       </PathRow>
       <Highlight
-        {...defaultProps}
         code={children}
         language={language}
         theme={getTheme(interiorTheme)}>

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.js
@@ -14,13 +14,10 @@ import Sidebar from './Sidebar';
 
 import useMetadata from '../../util/hooks/useMetadata';
 
-const Code = ({
-  children,
-  className: classNameProp = '',
-  path,
-  src,
-  hideCode = false,
-}) => {
+const Code = ({ children, className: classNameProp = '', metaData }) => {
+  const [path, setPath] = useState('');
+  const [src, setSrc] = useState('');
+  const [hideCode, setHideCode] = useState(false);
   const [hasMoreThanNineLines, setHasMoreThanNineLines] = useState(false);
   const [shouldShowMore, setShouldShowMore] = useState(false);
   const [isInlineCode, setIsInlineCode] = useState(false);
@@ -30,6 +27,29 @@ const Code = ({
       setIsInlineCode(true);
     }
   }, [classNameProp]);
+
+  useEffect(() => {
+    // metaData string is of format: path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
+    if (metaData) {
+      const metaDataObject = metaData.split(' ').reduce((obj, item) => {
+        const [key, value] = item.split('=');
+        obj[key] = value;
+        return obj;
+      }, {});
+
+      if (metaDataObject.path) {
+        setPath(metaDataObject.path);
+      }
+
+      if (metaDataObject.src) {
+        setSrc(metaDataObject.src);
+      }
+
+      if (metaDataObject.hideCode) {
+        setHideCode(true);
+      }
+    }
+  }, [metaData]);
 
   const { interiorTheme } = useMetadata();
   const language = classNameProp.replace(/language-/, '').replace('mdx', 'jsx');

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.js
@@ -14,7 +14,13 @@ import Sidebar from './Sidebar';
 
 import useMetadata from '../../util/hooks/useMetadata';
 
-const Code = ({ children, className: classNameProp = '', path, src }) => {
+const Code = ({
+  children,
+  className: classNameProp = '',
+  path,
+  src,
+  hideCode = false,
+}) => {
   const [hasMoreThanNineLines, setHasMoreThanNineLines] = useState(false);
   const [shouldShowMore, setShouldShowMore] = useState(false);
   const [isInlineCode, setIsInlineCode] = useState(false);
@@ -44,7 +50,7 @@ const Code = ({ children, className: classNameProp = '', path, src }) => {
     if (withoutTrailingEmptyLines && withoutTrailingEmptyLines.length > 9) {
       setHasMoreThanNineLines(true);
     }
-    if (shouldShowMore) {
+    if (shouldShowMore || !hideCode) {
       return withoutTrailingEmptyLines;
     }
     return withoutTrailingEmptyLines.slice(0, 9);
@@ -86,7 +92,7 @@ const Code = ({ children, className: classNameProp = '', path, src }) => {
           </div>
         )}
       </Highlight>
-      {hasMoreThanNineLines && (
+      {hideCode && hasMoreThanNineLines && (
         <button
           className={cx(styles.showMoreButton, {
             [styles.dark]: interiorTheme === 'dark',

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.module.scss
@@ -62,6 +62,7 @@ li .row {
   position: relative;
   overflow: auto;
   width: 100%;
+  text-wrap: wrap;
 }
 
 .sideBarMinHeight {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11291,7 +11291,7 @@ __metadata:
     react-helmet: "npm:^6.1.0"
     react-transition-group: "npm:^4.4.5"
     react-use: "npm:^17.5.0"
-    rehype-mdx-fenced-code-meta-support: "npm:^1.0.0"
+    rehype-mdx-fenced-code-meta-support: "npm:^1.0.4"
     remark-gfm: "npm:3.0.1"
     sass: "npm:^1.71.1"
     slugify: "npm:^1.6.6"
@@ -19718,12 +19718,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rehype-mdx-fenced-code-meta-support@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "rehype-mdx-fenced-code-meta-support@npm:1.0.0"
+"rehype-mdx-fenced-code-meta-support@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "rehype-mdx-fenced-code-meta-support@npm:1.0.4"
   dependencies:
     unist-util-visit: "npm:^5.0.0"
-  checksum: 10/678daf25871ce1c75107497c29c6a79bad65ca9f6b49689e12a5d5bb8585a0a502a00c723922409d2f2ea28b2efb01cf5b04464763541cd1f1b9b2faa907fb13
+  checksum: 10/8292b57d980e460c1f3258840f950d5043ab6aa66bf2120df170482c521b1d1e954d976a4e2cdfa17f39c04e53261102c6f444030564a9b1896f03fddd074561
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11291,6 +11291,7 @@ __metadata:
     react-helmet: "npm:^6.1.0"
     react-transition-group: "npm:^4.4.5"
     react-use: "npm:^17.5.0"
+    rehype-mdx-fenced-code-meta-support: "npm:^1.0.0"
     remark-gfm: "npm:3.0.1"
     sass: "npm:^1.71.1"
     slugify: "npm:^1.6.6"
@@ -19714,6 +19715,15 @@ __metadata:
     unified: "npm:^10.0.0"
     unist-util-remove-position: "npm:^4.0.0"
   checksum: 10/b1a4d5186245d16beb57626193933c221b3d1886a92a50166c5a383d5f98ac1c59c749b77a9af61f02e156b8c840f76a46cd891013c1286531482458163aea13
+  languageName: node
+  linkType: hard
+
+"rehype-mdx-fenced-code-meta-support@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "rehype-mdx-fenced-code-meta-support@npm:1.0.0"
+  dependencies:
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10/678daf25871ce1c75107497c29c6a79bad65ca9f6b49689e12a5d5bb8585a0a502a00c723922409d2f2ea28b2efb01cf5b04464763541cd1f1b9b2faa907fb13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes the following - 

- Show more button in Code blocks
- Added a prop to enable/disable Show more button in Code blocls
- Added text wrap to avoid horizontal scroll
- Added a new package that is traversing hast and adding a new property named metaData which is being passed as a prop

Should close - https://github.com/carbon-design-system/gatsby-theme-carbon/issues/868
