### PR TITLE
fix: add https to carbon for cloud link

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
+++ b/packages/gatsby-theme-carbon/src/components/Switcher/Switcher.js
@@ -99,7 +99,7 @@ const DefaultChildren = () => (
     <SwitcherLink href="http://ibm.biz/carbon4ibmproducts" isInternal>
       Carbon for IBM Products
     </SwitcherLink>
-    <SwitcherLink href="ibm.biz/carbon4cloud" isInternal>
+    <SwitcherLink href="https://ibm.biz/carbon4cloud" isInternal>
       Carbon for Cloud
     </SwitcherLink>
     <SwitcherLink href="https://www.ibm.com/standards/carbon/">

--- a/yarn.lock
+++ b/yarn.lock
@@ -9509,7 +9509,7 @@ __metadata:
   resolution: "example@workspace:packages/example"
   dependencies:
     gatsby: "npm:^4.25.8"
-    gatsby-theme-carbon: "npm:^3.4.14"
+    gatsby-theme-carbon: "npm:^3.4.15"
     react: "npm:^17.0.2"
     react-dom: "npm:^17.0.2"
   languageName: unknown
@@ -10891,7 +10891,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^3.4.14, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^3.4.15, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Missed the `https://` 🙈
Sorry for round two.

#### Changelog

**Changed**

- Fix link to Carbon for Cloud