### PR TITLE
Fix regression in code blocks

### DIFF
--- a/packages/example/src/pages/components/code-blocks.mdx
+++ b/packages/example/src/pages/components/code-blocks.mdx
@@ -26,7 +26,7 @@ This example overflows to demonstrate the text fading out under the side bar.
 
 <Title>Vertical overflow</Title>
 
-```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com hideCode=true
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com
 ## Path, src, hideCode w/ overflow
 
 This example demonstrates the show more button. This example demonstrates the
@@ -46,7 +46,7 @@ button.
 ## Code
 
 ````mdx
-```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com hideCode=true
+```markdown path=/directory/file.mdx src=https://gatsby.carbondesignsystem.com hideCode=false
 ### Path, src and hideCode
 
 This code snippet provides a `path`, a `src` and `hideCode` prop.
@@ -60,4 +60,4 @@ This code snippet provides a `path`, a `src` and `hideCode` prop.
 | language | string   | [Available languages.](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js)                                    |
 | src      | string   | The full url of a relevant link (source)                                                                                                                       |
 | path     | string   | A string indicating the filename or path. Due to markdown limitations this can only be a single word                                                           |
-| hideCode | boolean  | A boolean indicating if the code block should have a Show More button. Code block should have more than 9 lines to display the button. Default value = `false` |
+| hideCode | boolean  | A boolean indicating if the code block should have a Show More button. Code block should have more than 9 lines to display the button. Default value = `true` |

--- a/packages/gatsby-theme-carbon/src/components/Code/Code.js
+++ b/packages/gatsby-theme-carbon/src/components/Code/Code.js
@@ -17,7 +17,7 @@ import useMetadata from '../../util/hooks/useMetadata';
 const Code = ({ children, className: classNameProp = '', metaData }) => {
   const [path, setPath] = useState('');
   const [src, setSrc] = useState('');
-  const [hideCode, setHideCode] = useState(false);
+  const [hideCode, setHideCode] = useState(true);
   const [hasMoreThanNineLines, setHasMoreThanNineLines] = useState(false);
   const [shouldShowMore, setShouldShowMore] = useState(false);
   const [isInlineCode, setIsInlineCode] = useState(false);


### PR DESCRIPTION
This PR aims at removing the regression introduced by a new prop introduced in Code blocks.

#### Changelog
Changed the value of `hideCode` to `true` so that the blocks show a "Show more" button in all code blocks having more than 9 lines.