### PR TITLE
fix: remove vimeo example

### DIFF
--- a/packages/example/src/pages/components/Video/index.mdx
+++ b/packages/example/src/pages/components/Video/index.mdx
@@ -14,10 +14,6 @@ The `<Video>` component can render a Vimeo player or a html video player.
 
 ## Example
 
-<Title>Vimeo</Title>
-
-<Video title="Carbon homepage video" vimeoId="359578263" />
-
 <Title>Video</Title>
 
 <Video src="/videos/hero-video.mp4" poster="/images/poster.png">
@@ -34,12 +30,6 @@ The `<Video>` component can render a Vimeo player or a html video player.
 <Video src={localVideo} poster={localPoster} />
 
 ## Code
-
-<Title>Vimeo</Title>
-
-```mdx path=components/Video/Video.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/main/packages/gatsby-theme-carbon/src/components/Video
-<Video title="Carbon homepage video" vimeoId="322021187" />
-```
 
 <Title>Video</Title>
 
@@ -61,6 +51,12 @@ import localVideo from './local-video.mp4';
 import localPoster from './local-poster.jpg';
 
 <Video src={localVideo} poster={localPoster} />
+```
+
+<Title>Vimeo</Title>
+
+```mdx path=components/Video/Video.js src=https://github.com/carbon-design-system/gatsby-theme-carbon/tree/main/packages/gatsby-theme-carbon/src/components/Video
+<Video title="Carbon homepage video" vimeoId="322021187" />
 ```
 
 ### Props


### PR DESCRIPTION
Ref #https://github.com/carbon-design-system/carbon/issues/16078



#### Changelog


**Removed**

- Remove Vimeo example, not allowed by IBM and was flagged by compliance team
