### PR TITLE
[Draft]: Left nav tree

### DIFF
--- a/packages/example/src/data/nav-items.yaml
+++ b/packages/example/src/data/nav-items.yaml
@@ -4,6 +4,18 @@
 - title: Demo
   pages:
     - path: /demo
+- title: Level two
+  pages:
+    - title: Page one
+      path: /level-two/page-one
+    - title: Page two
+      path: /level-two/page-two
+    - title: Level three
+      pages:
+        - title: Page three
+          path: /level-two/page-three
+        - title: Page four
+          path: /level-two/page-four
 - title: Gallery
   pages:
     - path: /gallery

--- a/packages/example/src/pages/level-two/page-four.mdx
+++ b/packages/example/src/pages/level-two/page-four.mdx
@@ -1,0 +1,95 @@
+---
+title: Level two page four
+description: Quick start guide for getting acclimated with gatsby-theme-carbon
+---
+
+<PageDescription>
+
+This project is a
+[Gatsby theme](https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/)
+that empowers developers, writers, and designers to create fast, accessible
+sites that look and feel like Carbon. Follow along to start creating your own
+site.
+
+</PageDescription>
+
+## First steps
+
+1. **Create your site** – use the gatsby CLI to bootstrap your site with the
+   starter
+
+   ```sh
+   npx gatsby new my-carbon-site https://github.com/carbon-design-system/gatsby-starter-carbon-theme
+   ```
+
+2. **Start developing** – navigate into your directory with `cd my-carbon-site`.
+
+   Start it up using one of the following snippets. You can tell which command
+   to use based on the lock file at the root of your project (`yarn.lock` for
+   yarn and `package-lock.json` for npm). For yarn, type `yarn dev` for npm,
+   you’ll use `npm run dev`.
+
+3. **Make some changes!** – open [localhost:8000](//localhost:8000) in your
+   browser to see your site running.
+
+   Each of the Items in your side bar correlates to a MDX file in your
+   `src/pages/` directory. Navigate to a site and try editing the corresponding
+   markdown file. You’ll be able to see it update live!
+
+## 👀 Watch a newbie try it out
+
+This is a [demo of a new Carbon team member spinning up a Gatsby Theme Carbon
+site](https://player.vimeo.com/video/437931932 while following the steps listed above.
+To forward through the introduction, play from min `3:50`.
+
+## 🔍 What’s in here?
+
+Lets check out the structure of our project
+
+```shell
+.
+├── LICENSE
+├── README.md
+├── gatsby-config.js
+├── node_modules
+├── package.json
+├── public
+├── src
+│   ├── data
+│   ├── gatsby-theme-carbon
+│   ├── images
+│   └── pages
+└── yarn.lock
+```
+
+1.  **`/node_modules`**: This directory contains all of the modules of code that
+    your project depends on (npm packages) are automatically installed.
+
+1.  **`/src`**: This directory will contain all of the code related to what you
+    will see on the front-end of your site.
+
+    - **data** this is where you’ll update your sidebar order and contents
+    - **images** you can colocate your images here or store them next to your
+      pages, whichver you chose
+    - **gatsby-theme-carbon** this is where you’ll override (known as shadowing)
+      the default `gatsby-theme-carbon` components
+    - **pages** This is where most of your content will live. You’ll represent
+      each page with an MDX file.
+
+1.  **`.gitignore`**: This file tells git which files it should not track / not
+    maintain a version history for.
+
+1.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby
+    site. This is where you can specify information about your site (metadata)
+    like the site title and description. You’ll notice that all of the
+    configuration for the site is coming from `gatsby-theme-carbon`
+
+1.  **`LICENSE`**: Gatsby is licensed under the Apache 2.0 license.
+
+1.  **`yarn.lock`** (See `package.json` below, first). This is an automatically
+    generated file based on the exact versions of your npm dependencies that
+    were installed for your project. **(You won’t change this file directly).**
+
+1.  **`package.json`**: A manifest file for Node.js projects, which includes
+    things like metadata (the project’s name, author, etc). This manifest is how
+    npm knows which packages to install for your project.

--- a/packages/example/src/pages/level-two/page-one.mdx
+++ b/packages/example/src/pages/level-two/page-one.mdx
@@ -1,0 +1,95 @@
+---
+title: Level two page one
+description: Quick start guide for getting acclimated with gatsby-theme-carbon
+---
+
+<PageDescription>
+
+This project is a
+[Gatsby theme](https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/)
+that empowers developers, writers, and designers to create fast, accessible
+sites that look and feel like Carbon. Follow along to start creating your own
+site.
+
+</PageDescription>
+
+## First steps
+
+1. **Create your site** – use the gatsby CLI to bootstrap your site with the
+   starter
+
+   ```sh
+   npx gatsby new my-carbon-site https://github.com/carbon-design-system/gatsby-starter-carbon-theme
+   ```
+
+2. **Start developing** – navigate into your directory with `cd my-carbon-site`.
+
+   Start it up using one of the following snippets. You can tell which command
+   to use based on the lock file at the root of your project (`yarn.lock` for
+   yarn and `package-lock.json` for npm). For yarn, type `yarn dev` for npm,
+   you’ll use `npm run dev`.
+
+3. **Make some changes!** – open [localhost:8000](//localhost:8000) in your
+   browser to see your site running.
+
+   Each of the Items in your side bar correlates to a MDX file in your
+   `src/pages/` directory. Navigate to a site and try editing the corresponding
+   markdown file. You’ll be able to see it update live!
+
+## 👀 Watch a newbie try it out
+
+This is a [demo of a new Carbon team member spinning up a Gatsby Theme Carbon
+site](https://player.vimeo.com/video/437931932 while following the steps listed above.
+To forward through the introduction, play from min `3:50`.
+
+## 🔍 What’s in here?
+
+Lets check out the structure of our project
+
+```shell
+.
+├── LICENSE
+├── README.md
+├── gatsby-config.js
+├── node_modules
+├── package.json
+├── public
+├── src
+│   ├── data
+│   ├── gatsby-theme-carbon
+│   ├── images
+│   └── pages
+└── yarn.lock
+```
+
+1.  **`/node_modules`**: This directory contains all of the modules of code that
+    your project depends on (npm packages) are automatically installed.
+
+1.  **`/src`**: This directory will contain all of the code related to what you
+    will see on the front-end of your site.
+
+    - **data** this is where you’ll update your sidebar order and contents
+    - **images** you can colocate your images here or store them next to your
+      pages, whichver you chose
+    - **gatsby-theme-carbon** this is where you’ll override (known as shadowing)
+      the default `gatsby-theme-carbon` components
+    - **pages** This is where most of your content will live. You’ll represent
+      each page with an MDX file.
+
+1.  **`.gitignore`**: This file tells git which files it should not track / not
+    maintain a version history for.
+
+1.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby
+    site. This is where you can specify information about your site (metadata)
+    like the site title and description. You’ll notice that all of the
+    configuration for the site is coming from `gatsby-theme-carbon`
+
+1.  **`LICENSE`**: Gatsby is licensed under the Apache 2.0 license.
+
+1.  **`yarn.lock`** (See `package.json` below, first). This is an automatically
+    generated file based on the exact versions of your npm dependencies that
+    were installed for your project. **(You won’t change this file directly).**
+
+1.  **`package.json`**: A manifest file for Node.js projects, which includes
+    things like metadata (the project’s name, author, etc). This manifest is how
+    npm knows which packages to install for your project.

--- a/packages/example/src/pages/level-two/page-three.mdx
+++ b/packages/example/src/pages/level-two/page-three.mdx
@@ -1,0 +1,95 @@
+---
+title: Level three page one
+description: Quick start guide for getting acclimated with gatsby-theme-carbon
+---
+
+<PageDescription>
+
+This project is a
+[Gatsby theme](https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/)
+that empowers developers, writers, and designers to create fast, accessible
+sites that look and feel like Carbon. Follow along to start creating your own
+site.
+
+</PageDescription>
+
+## First steps
+
+1. **Create your site** – use the gatsby CLI to bootstrap your site with the
+   starter
+
+   ```sh
+   npx gatsby new my-carbon-site https://github.com/carbon-design-system/gatsby-starter-carbon-theme
+   ```
+
+2. **Start developing** – navigate into your directory with `cd my-carbon-site`.
+
+   Start it up using one of the following snippets. You can tell which command
+   to use based on the lock file at the root of your project (`yarn.lock` for
+   yarn and `package-lock.json` for npm). For yarn, type `yarn dev` for npm,
+   you’ll use `npm run dev`.
+
+3. **Make some changes!** – open [localhost:8000](//localhost:8000) in your
+   browser to see your site running.
+
+   Each of the Items in your side bar correlates to a MDX file in your
+   `src/pages/` directory. Navigate to a site and try editing the corresponding
+   markdown file. You’ll be able to see it update live!
+
+## 👀 Watch a newbie try it out
+
+This is a [demo of a new Carbon team member spinning up a Gatsby Theme Carbon
+site](https://player.vimeo.com/video/437931932 while following the steps listed above.
+To forward through the introduction, play from min `3:50`.
+
+## 🔍 What’s in here?
+
+Lets check out the structure of our project
+
+```shell
+.
+├── LICENSE
+├── README.md
+├── gatsby-config.js
+├── node_modules
+├── package.json
+├── public
+├── src
+│   ├── data
+│   ├── gatsby-theme-carbon
+│   ├── images
+│   └── pages
+└── yarn.lock
+```
+
+1.  **`/node_modules`**: This directory contains all of the modules of code that
+    your project depends on (npm packages) are automatically installed.
+
+1.  **`/src`**: This directory will contain all of the code related to what you
+    will see on the front-end of your site.
+
+    - **data** this is where you’ll update your sidebar order and contents
+    - **images** you can colocate your images here or store them next to your
+      pages, whichver you chose
+    - **gatsby-theme-carbon** this is where you’ll override (known as shadowing)
+      the default `gatsby-theme-carbon` components
+    - **pages** This is where most of your content will live. You’ll represent
+      each page with an MDX file.
+
+1.  **`.gitignore`**: This file tells git which files it should not track / not
+    maintain a version history for.
+
+1.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby
+    site. This is where you can specify information about your site (metadata)
+    like the site title and description. You’ll notice that all of the
+    configuration for the site is coming from `gatsby-theme-carbon`
+
+1.  **`LICENSE`**: Gatsby is licensed under the Apache 2.0 license.
+
+1.  **`yarn.lock`** (See `package.json` below, first). This is an automatically
+    generated file based on the exact versions of your npm dependencies that
+    were installed for your project. **(You won’t change this file directly).**
+
+1.  **`package.json`**: A manifest file for Node.js projects, which includes
+    things like metadata (the project’s name, author, etc). This manifest is how
+    npm knows which packages to install for your project.

--- a/packages/example/src/pages/level-two/page-two.mdx
+++ b/packages/example/src/pages/level-two/page-two.mdx
@@ -1,0 +1,95 @@
+---
+title: Level two page two
+description: Quick start guide for getting acclimated with gatsby-theme-carbon
+---
+
+<PageDescription>
+
+This project is a
+[Gatsby theme](https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/)
+that empowers developers, writers, and designers to create fast, accessible
+sites that look and feel like Carbon. Follow along to start creating your own
+site.
+
+</PageDescription>
+
+## First steps
+
+1. **Create your site** – use the gatsby CLI to bootstrap your site with the
+   starter
+
+   ```sh
+   npx gatsby new my-carbon-site https://github.com/carbon-design-system/gatsby-starter-carbon-theme
+   ```
+
+2. **Start developing** – navigate into your directory with `cd my-carbon-site`.
+
+   Start it up using one of the following snippets. You can tell which command
+   to use based on the lock file at the root of your project (`yarn.lock` for
+   yarn and `package-lock.json` for npm). For yarn, type `yarn dev` for npm,
+   you’ll use `npm run dev`.
+
+3. **Make some changes!** – open [localhost:8000](//localhost:8000) in your
+   browser to see your site running.
+
+   Each of the Items in your side bar correlates to a MDX file in your
+   `src/pages/` directory. Navigate to a site and try editing the corresponding
+   markdown file. You’ll be able to see it update live!
+
+## 👀 Watch a newbie try it out
+
+This is a [demo of a new Carbon team member spinning up a Gatsby Theme Carbon
+site](https://player.vimeo.com/video/437931932 while following the steps listed above.
+To forward through the introduction, play from min `3:50`.
+
+## 🔍 What’s in here?
+
+Lets check out the structure of our project
+
+```shell
+.
+├── LICENSE
+├── README.md
+├── gatsby-config.js
+├── node_modules
+├── package.json
+├── public
+├── src
+│   ├── data
+│   ├── gatsby-theme-carbon
+│   ├── images
+│   └── pages
+└── yarn.lock
+```
+
+1.  **`/node_modules`**: This directory contains all of the modules of code that
+    your project depends on (npm packages) are automatically installed.
+
+1.  **`/src`**: This directory will contain all of the code related to what you
+    will see on the front-end of your site.
+
+    - **data** this is where you’ll update your sidebar order and contents
+    - **images** you can colocate your images here or store them next to your
+      pages, whichver you chose
+    - **gatsby-theme-carbon** this is where you’ll override (known as shadowing)
+      the default `gatsby-theme-carbon` components
+    - **pages** This is where most of your content will live. You’ll represent
+      each page with an MDX file.
+
+1.  **`.gitignore`**: This file tells git which files it should not track / not
+    maintain a version history for.
+
+1.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby
+    site. This is where you can specify information about your site (metadata)
+    like the site title and description. You’ll notice that all of the
+    configuration for the site is coming from `gatsby-theme-carbon`
+
+1.  **`LICENSE`**: Gatsby is licensed under the Apache 2.0 license.
+
+1.  **`yarn.lock`** (See `package.json` below, first). This is an automatically
+    generated file based on the exact versions of your npm dependencies that
+    were installed for your project. **(You won’t change this file directly).**
+
+1.  **`package.json`**: A manifest file for Node.js projects, which includes
+    things like metadata (the project’s name, author, etc). This manifest is how
+    npm knows which packages to install for your project.

--- a/packages/gatsby-theme-carbon/gatsby-node.mjs
+++ b/packages/gatsby-theme-carbon/gatsby-node.mjs
@@ -103,9 +103,14 @@ export const createSchemaCustomization = ({ actions, schema }) => {
       title: String
       path: String!
     }
+    type NavItemsSubLevelYaml {
+      title: String
+      path: String
+      pages: [NavItemsYamlPage]
+    }
     type NavItemsYaml implements Node {
       title: String!
-      pages: [NavItemsYamlPage]!
+      pages: [NavItemsSubLevelYaml]!
       hasDivider: Boolean
     }`,
     schema.buildObjectType({

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
@@ -1,4 +1,10 @@
-import React, { useContext, useRef, useEffect } from 'react';
+import React, {
+  useContext,
+  useRef,
+  useEffect,
+  useCallback,
+  useState,
+} from 'react';
 import { SideNav, SideNavItems } from '@carbon/react';
 import { useNavItems } from '../../util/NavItems';
 
@@ -9,6 +15,7 @@ import LeftNavResourceLinks from './ResourceLinks';
 import LeftNavWrapper from './LeftNavWrapper';
 import * as styles from './LeftNav.module.scss';
 import useMetadata from '../../util/hooks/useMetadata';
+import LeftNavTree from './LeftNavTree';
 
 const LeftNav = (props) => {
   const {
@@ -18,24 +25,52 @@ const LeftNav = (props) => {
     toggleNavState,
   } = useContext(NavContext);
 
+  const [isTreeView, setIsTreeView] = useState();
+
   const sideNavRef = useRef();
   const sideNavListRef = useRef();
 
-  useEffect(() => {
-    sideNavListRef.current = sideNavRef.current.querySelector('.sidenav-list');
-  }, []);
+  const navItems = useNavItems();
 
-  useEffect(() => {
-    sideNavListRef.current.addEventListener('scroll', (e) => {
-      setLeftNavScrollTop(e.target.scrollTop);
+  const hasNestedLevels = useCallback(() => {
+    let nestedLevels = false;
+
+    navItems.forEach((navItem) => {
+      navItem.pages?.forEach((levelTwoNavItem) => {
+        if (levelTwoNavItem.pages && levelTwoNavItem.pages.length > 1) {
+          nestedLevels = true;
+        }
+      });
     });
-  }, [setLeftNavScrollTop]);
+    return nestedLevels;
+  }, [navItems]);
 
   useEffect(() => {
-    if (leftNavScrollTop >= 0 && !sideNavListRef?.current.scrollTop) {
-      sideNavListRef.current.scrollTop = leftNavScrollTop;
+    setIsTreeView(hasNestedLevels());
+  }, [navItems]);
+
+  useEffect(() => {
+    if (!isTreeView) {
+      sideNavListRef.current =
+        sideNavRef.current.querySelector('.sidenav-list');
     }
-  }, [leftNavScrollTop]);
+  }, [isTreeView]);
+
+  useEffect(() => {
+    if (!isTreeView) {
+      sideNavListRef.current.addEventListener('scroll', (e) => {
+        setLeftNavScrollTop(e.target.scrollTop);
+      });
+    }
+  }, [setLeftNavScrollTop, isTreeView]);
+
+  useEffect(() => {
+    if (!isTreeView) {
+      if (leftNavScrollTop >= 0 && !sideNavListRef?.current.scrollTop) {
+        sideNavListRef.current.scrollTop = leftNavScrollTop;
+      }
+    }
+  }, [leftNavScrollTop, isTreeView]);
 
   const getLeftNavClassNames = () => {
     if (props.theme === 'dark') {
@@ -44,7 +79,6 @@ const LeftNav = (props) => {
     return styles.sideNavWhite;
   };
 
-  const navItems = useNavItems();
   const { navigationStyle } = useMetadata();
 
   const closeSwitcher = () => {
@@ -57,25 +91,33 @@ const LeftNav = (props) => {
       expanded={leftNavIsOpen}
       onClick={closeSwitcher}
       onKeyPress={closeSwitcher}>
-      <SideNav
-        ref={sideNavRef}
-        aria-label="Side navigation"
-        expanded={navigationStyle ? leftNavIsOpen : true}
-        defaultExpanded={!navigationStyle}
-        isPersistent={!navigationStyle}
-        className={getLeftNavClassNames()}>
-        <SideNavItems className="sidenav-list">
-          {navItems.map((item, i) => (
-            <LeftNavItem
-              items={item.pages}
-              category={item.title}
-              key={i}
-              hasDivider={item.hasDivider}
-            />
-          ))}
-          <LeftNavResourceLinks />
-        </SideNavItems>
-      </SideNav>
+      {isTreeView ? (
+        <>
+          <LeftNavTree items={navItems}></LeftNavTree>
+          {/* <LeftNavResourceLinks /> */}
+        </>
+      ) : (
+        <SideNav
+          ref={sideNavRef}
+          aria-label="Side navigation"
+          expanded={navigationStyle ? leftNavIsOpen : true}
+          defaultExpanded={!navigationStyle}
+          isPersistent={!navigationStyle}
+          className={getLeftNavClassNames()}>
+          <SideNavItems className="sidenav-list">
+            {typeof isTreeView !== 'undefined' &&
+              navItems.map((item, i) => (
+                <LeftNavItem
+                  items={item.pages}
+                  category={item.title}
+                  key={i}
+                  hasDivider={item.hasDivider}
+                />
+              ))}
+            <LeftNavResourceLinks />
+          </SideNavItems>
+        </SideNav>
+      )}
     </LeftNavWrapper>
   );
 };

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -1,0 +1,161 @@
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { useLocation } from '@reach/router';
+import { Theme, TreeNode, TreeView } from '@carbon/react';
+import { Link } from 'gatsby';
+
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as styles from './LeftNavTree.module.scss';
+import { dfs } from '../../util/NavTree';
+
+import slugify from 'slugify';
+
+const LeftNavTree = ({ items }) => {
+  const [itemNodes, setItemNodes] = useState([]);
+  const [treeActiveItem, setTreeActiveItem] = useState({});
+  const [activePath, setActivePath] = useState('');
+  const location = useLocation();
+
+  useEffect(() => {
+    const newItemNodeArray = [];
+    // method to set isBranch value for branch nodes
+    const assignNodeType = (item) => {
+      // branch node with more than 1 leaf nodes
+      if (item.pages && item.pages.length > 1) {
+        item.isBranch = true;
+        item.pages.forEach((SubNavItem, i) => {
+          return assignNodeType(SubNavItem);
+        });
+      }
+      // if it is branch node with only one leaf node, convert it to a leaf node
+      else if (item.pages && item.pages.length) {
+        item.path = item.pages[0].path;
+        item.pages = null;
+      }
+      return item;
+    };
+
+    items.forEach((item) => {
+      newItemNodeArray.push(assignNodeType(item));
+    });
+
+    // Create hierarchical, unique node ids for all nodes in the nav tree
+    dfs(newItemNodeArray, (evalNode) => {
+      if (!evalNode.parentNodeId) {
+        evalNode.parentNodeId = 'left_nav_tree';
+      }
+
+      // Combine the parent's node id with the current node's id
+      const currentNodeId = evalNode.title
+        .toLocaleLowerCase()
+        .replace(/\s/g, '');
+      evalNode.id = `${evalNode.parentNodeId}_${currentNodeId}`;
+
+      // Set the parent node id of each child of this node to the newly generated id
+      evalNode.pages?.forEach((child) => {
+        child.parentNodeId = evalNode.id;
+      });
+
+      return false;
+    });
+
+    setItemNodes(newItemNodeArray);
+  }, [items]);
+
+  useEffect(() => {
+    const stripTrailingSlash = (str) => {
+      return str.endsWith('/') ? str.slice(0, -1) : str;
+    };
+
+    setActivePath(stripTrailingSlash(location.pathname));
+  }, [location.pathname]);
+
+  const getItemPath = (item) => {
+    return item.path || slugify(item.title, { lower: true, strict: true });
+  };
+
+  const removeHashAndQuery = (path) => path?.split('?')?.[0]?.split('#')?.[0];
+
+  const isTreeNodeActive = useCallback(
+    (node) => {
+      return getItemPath(node) === removeHashAndQuery(activePath);
+    },
+    [activePath]
+  );
+
+  useEffect(() => {
+    const activeNode = dfs(itemNodes, isTreeNodeActive);
+    setTreeActiveItem(activeNode);
+  }, [isTreeNodeActive, itemNodes]);
+
+  const isTreeNodeExpanded = (node) => {
+    return !!dfs([node], (evalNode) =>
+      evalNode.pages?.some((page) => page.id === treeActiveItem?.id)
+    );
+  };
+
+  function renderTree({ nodes }) {
+    if (!nodes) {
+      return;
+    }
+    return nodes.map((node) => {
+      let label = node.title;
+
+      if (node.path) {
+        label = (
+          <Link
+            to={node.path}
+            className={styles.anchor}
+            // tabIndex={visible ? 0 : '-1'}
+          >
+            {node.title}
+          </Link>
+        );
+      }
+
+      return (
+        <TreeNode
+          id={node.id}
+          key={node.id}
+          label={label}
+          value={node.title}
+          isExpanded={isTreeNodeExpanded(node)}
+          className={clsx({
+            'cds--tree-node--active': node.id === treeActiveItem?.id,
+            'cds--tree-node--selected': node.id === treeActiveItem?.id,
+          })}
+          onSelect={() => {
+            node.path && setTreeActiveItem(node);
+          }}>
+          {node.isBranch &&
+            renderTree({
+              nodes: node.pages,
+            })}
+        </TreeNode>
+      );
+    });
+  }
+
+  return (
+    <Theme className={styles.container} theme="g10">
+      <TreeView label="Side navigation" hideLabel>
+        {renderTree({ nodes: itemNodes })}
+      </TreeView>
+    </Theme>
+  );
+};
+
+LeftNavTree.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      path: PropTypes.string,
+      pages: PropTypes.array,
+      hasDivider: PropTypes.bool,
+    })
+  ),
+};
+
+const areEqual = (prevProps, nextProps) => true;
+
+export default memo(LeftNavTree, areEqual);

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.module.scss
@@ -1,0 +1,134 @@
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+@use '@carbon/react/scss/utilities/convert' as convert;
+
+.container {
+  height: 100% !important;
+  margin: spacing.$spacing-10 0;
+  background-color: white !important; //theme.$layer-02;
+
+  // fix left alignment because we are hiding the left icon
+  :global(.cds--tree-leaf-node) {
+    padding-left: spacing.$spacing-05;
+  }
+
+  // label font and cursor overrides
+  :global(.cds--tree-node__label) {
+    position: relative;
+    cursor: pointer;
+    @include type.type-style('heading-01');
+  }
+
+  // override g10 selected background
+  :global(.cds--tree-node--selected > .cds--tree-node__label),
+  :global(.cds--tree-node--selected > .cds--tree-node__label::before) {
+    background-color: transparent;
+  }
+
+  // bold selected labels and make darker
+  :global(.cds--tree-node[aria-expanded='true'] > .cds--tree-node__label) {
+    color: theme.$text-primary;
+    @include type.type-style('heading-01');
+  }
+
+  // override g10 hover background
+  :global(.cds--tree-node__label:hover),
+  :global(.cds--tree-node--selected > .cds--tree-node__label:hover) {
+    background-color: theme.$layer-02;
+  }
+
+  // child labels have normal font weight
+  :global(.cds--tree-node__children .cds--tree-node__label) {
+    @include type.type-style('body-compact-01');
+  }
+
+  // move all div padding to the anchor
+  :global(.cds--tree-node:not(.cds--tree-parent-node) .cds--tree-node__label) {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  // anchor links fill entire label box
+  .anchor {
+    width: calc(100% + spacing.$spacing-05);
+    padding: 0.375rem spacing.$spacing-05;
+    margin-left: -(spacing.$spacing-05);
+    color: theme.$text-secondary;
+    text-decoration: none;
+  }
+
+  // anchor links are darker on hover
+  .anchor:hover {
+    color: theme.$text-primary;
+  }
+
+  // nested anchor link
+  :global(.cds--tree-node__children) .anchor {
+    width: calc(100% + spacing.$spacing-07);
+    padding-left: spacing.$spacing-07;
+    margin-left: -(spacing.$spacing-07);
+  }
+
+  // have anchor selected match label selected
+  :global(.cds--tree-node--selected > .cds--tree-node__label) .anchor {
+    position: relative;
+    background: theme.$background-selected;
+    color: theme.$text-primary;
+    @include type.type-style('heading-01');
+
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0.25rem;
+      height: 100%;
+      background-color: theme.$border-interactive;
+      content: '';
+    }
+  }
+
+  // nested 2 deep anchor link
+  :global(.cds--tree-node__children > li > .cds--tree-node__children) .anchor {
+    width: calc(100% + spacing.$spacing-09);
+    padding-left: spacing.$spacing-09;
+    margin-left: -(spacing.$spacing-09);
+  }
+
+  // expand toggle click target
+  :global(.cds--tree-parent-node__toggle) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin-top: 0;
+    margin-right: 0;
+  }
+
+  // custom icon
+  :global(.cds--tree-parent-node__toggle::after) {
+    position: absolute;
+    top: spacing.$spacing-03;
+    right: spacing.$spacing-05;
+    display: block;
+    width: convert.rem(16px);
+    height: convert.rem(16px);
+    background-image: url("data:image/svg+xml,%3Csvg focusable='false' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg' fill='currentColor' width='16' height='16' viewBox='0 0 16 16' aria-hidden='true' class='cds--tree-node__icon'%3E%3Cpath d='M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z'%3E%3C/path%3E%3C/svg%3E%0A");
+    content: '';
+  }
+
+  // hide original icon
+  :global(.cds--tree-parent-node__toggle-icon) {
+    display: none;
+  }
+
+  // parent tree node open
+  :global(.cds--tree-node[aria-expanded='true']) {
+    > * > :global(.cds--tree-parent-node__toggle::after) {
+      transform: rotate(180deg);
+    }
+  }
+}

--- a/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.js
+++ b/packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.js
@@ -17,6 +17,10 @@ const useNavigationList = () => {
             pages {
               title
               path
+              pages {
+                path
+                title
+              }
             }
           }
         }
@@ -75,7 +79,7 @@ const useNavigationItems = ({ tabs, location }) => {
     : unPrefixedPathname.replace(/\/$/, ''); // removes the last syalash
 
   const navIndex = navigationList.findIndex((item) =>
-    item.path.includes(currentNavigationItem)
+    item.path?.includes(currentNavigationItem)
   );
 
   return {

--- a/packages/gatsby-theme-carbon/src/util/NavItems.js
+++ b/packages/gatsby-theme-carbon/src/util/NavItems.js
@@ -12,6 +12,10 @@ export function useNavItems() {
             pages {
               title
               path
+              pages {
+                path
+                title
+              }
             }
             hasDivider
           }

--- a/packages/gatsby-theme-carbon/src/util/NavTree.js
+++ b/packages/gatsby-theme-carbon/src/util/NavTree.js
@@ -1,0 +1,20 @@
+/**
+ * Iterates through all nodes in a tree and stops if a returnFunction() condition is met
+ * @param {{[key]: any, pages: object[]}[]} nodes tree
+ * @returns {void}
+ */
+export const dfs = (nodes, returnFunction) => {
+  let node;
+  const stack = [];
+  stack.push(...nodes);
+  while (stack.length > 0) {
+    node = stack.pop();
+    if (returnFunction(node)) {
+      return node;
+    } else {
+      node.pages?.forEach((item) => {
+        stack.push(item);
+      });
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10553,7 +10553,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.0.3"
+    gatsby-theme-carbon: "npm:^4.0.4"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11863,7 +11863,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.0.3, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.0.4, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes #1363 

Add support for level two nesting in left side navigation menu using carbon's TreeView component.

Screenshot of side nav with 2 level nested side nav
<img width="1791" alt="image" src="https://github.com/user-attachments/assets/05552778-a499-46fa-8337-339c21c39688">


#### Changelog

**New**

- packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
- packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.module.scss
- packages/gatsby-theme-carbon/src/util/NavTree.js
- packages/example/src/pages/level-two -  dummy pages for the demo of 2 level nesting


**Changed**

- packages/example/src/data/nav-items.yaml
- packages/gatsby-theme-carbon/gatsby-node.mjs
- packages/gatsby-theme-carbon/src/util/NavItems.js
- packages/gatsby-theme-carbon/src/components/LeftNav/LeftNav.js
- packages/gatsby-theme-carbon/src/components/NextPrevious/NextPrevious.js

**Removed**

- none

The below listed are the pending tasks/known issues which needs to be fixed
- [ ] Next & Previous links not working properly for level 2 pages
- [ ] Style customisation as per [Figma](https://www.figma.com/design/gmlnTUu8PQtgJoiHnkgzXd/IBM-Product-PAL-IA?node-id=471-2961&t=X78Zjjpl737r0OvP-0)
- [ ] if Level 2 contains only one item render it as level 1 leaf node
- [ ] Resource links are not working with TreeNav as it is created using SideNavLink component

