### PR TITLE
fix(leftnavtree): menu is not activated when the URL has pathprefix

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -10,12 +10,14 @@ import * as styles from './LeftNavTree.module.scss';
 import { dfs } from '../../util/NavTree';
 
 import LeftNavResourceLinks from './ResourceLinks';
+import usePathprefix from '../../util/hooks/usePathprefix';
 
 const LeftNavTree = ({ items, theme }) => {
   const [itemNodes, setItemNodes] = useState([]);
   const [treeActiveItem, setTreeActiveItem] = useState({});
   const [activePath, setActivePath] = useState('');
   const location = useLocation();
+  const pathPrefix = usePathprefix();
 
   const themeValue = theme === 'dark' ? 'g100' : theme;
 
@@ -66,7 +68,13 @@ const LeftNavTree = ({ items, theme }) => {
   useEffect(() => {
     const stripTrailingSlash = (str) =>
       str.endsWith('/') ? str.slice(0, -1) : str;
-    setActivePath(stripTrailingSlash(location.pathname));
+
+    console.log(pathPrefix);
+
+    let base = pathPrefix
+      ? location.pathname.replace(pathPrefix, '')
+      : location.pathname;
+    setActivePath(stripTrailingSlash(base));
   }, [location.pathname]);
 
   const getItemPath = (item) =>

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -69,8 +69,6 @@ const LeftNavTree = ({ items, theme }) => {
     const stripTrailingSlash = (str) =>
       str.endsWith('/') ? str.slice(0, -1) : str;
 
-    console.log(pathPrefix);
-
     let base = pathPrefix
       ? location.pathname.replace(pathPrefix, '')
       : location.pathname;

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -69,7 +69,7 @@ const LeftNavTree = ({ items, theme }) => {
     const stripTrailingSlash = (str) =>
       str.endsWith('/') ? str.slice(0, -1) : str;
 
-    let base = pathPrefix
+    const base = pathPrefix
       ? location.pathname.replace(pathPrefix, '')
       : location.pathname;
     setActivePath(stripTrailingSlash(base));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10595,7 +10595,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.0.7"
+    gatsby-theme-carbon: "npm:^4.0.8"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11905,7 +11905,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.0.7, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.0.8, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION

fixes issue where treenav isn't responding correctly to url paths in carbon-for-products-website.

#### Changelog

**Changed**

- Removed the pathPrefix from the location.path value before comparing it with the menu item path.
