### PR TITLE
fix(leftnavtree): highlight nav menu item for tabbed pages in level2

### DIFF
--- a/packages/example/src/data/nav-items.yaml
+++ b/packages/example/src/data/nav-items.yaml
@@ -15,7 +15,9 @@
         - title: Demo page 1
           path: /demo-level-1/demo-level-2/demo-page-1
         - title: Demo page 2
-          path: /demo-level-1/demo-level-2/demo-page-2
+          path: /demo-level-1/demo-level-2/demo-page-2/tab-1
+        - title: Demo page 3
+          path: /demo-level-1/demo-level-2/demo-page-3
 - title: Gallery
   pages:
     - path: /gallery

--- a/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-2/tab-1.mdx
+++ b/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-2/tab-1.mdx
@@ -1,5 +1,6 @@
 ---
 title: Demo page 2
+tabs: ['Tab 1', 'Tab 2']
 description: Demonstration of nested levels of navigation feature.
 ---
 

--- a/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-2/tab-2.mdx
+++ b/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-2/tab-2.mdx
@@ -1,0 +1,15 @@
+---
+title: Demo page 2
+tabs: ['Tab 1', 'Tab 2']
+description: Demonstration of nested levels of navigation feature.
+---
+
+<PageDescription>
+
+This is a demonstration of nested levels of navigation feature. This example
+showcases how you can effectively organize and access hierarchical content
+within your Gatsby application. For detailed instructions on setting up nested
+levels of navigation, please refer to our
+[Sidebar Navigation guide](https://gatsby.carbondesignsystem.com/guides/navigation/sidebar/).
+
+</PageDescription>

--- a/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-3.mdx
+++ b/packages/example/src/pages/demo-level-1/demo-level-2/demo-page-3.mdx
@@ -1,0 +1,14 @@
+---
+title: Demo page 3
+description: Demonstration of nested levels of navigation feature.
+---
+
+<PageDescription>
+
+This is a demonstration of nested levels of navigation feature. This example
+showcases how you can effectively organize and access hierarchical content
+within your Gatsby application. For detailed instructions on setting up nested
+levels of navigation, please refer to our
+[Sidebar Navigation guide](https://gatsby.carbondesignsystem.com/guides/navigation/sidebar/).
+
+</PageDescription>

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -85,9 +85,10 @@ const LeftNavTree = ({ items, theme, pathPrefix }) => {
   const isTabActive = useCallback(
     (node) => {
       const pathname = removeHashAndQuery(activePath);
+      const tabRootPath = pathname.split('/').slice(0, -1).join('/');
+
       const isActive =
-        `${node.path?.split('/')[1]}/${node.path?.split('/')[2]}` ===
-        `${pathname.split('/')[1]}/${pathname.split('/')[2]}`;
+        node.path?.split('/').slice(0, -1).join('/') === tabRootPath;
 
       return isActive;
     },

--- a/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
+++ b/packages/gatsby-theme-carbon/src/components/LeftNav/LeftNavTree.js
@@ -96,12 +96,14 @@ const LeftNavTree = ({ items, theme, pathPrefix }) => {
   );
 
   useEffect(() => {
-    let activeNode = dfs(itemNodes, isTreeNodeActive);
-    if (!activeNode) {
-      activeNode = dfs(itemNodes, isTabActive);
+    if (activePath) {
+      let activeNode = dfs(itemNodes, isTreeNodeActive);
+      if (!activeNode) {
+        activeNode = dfs(itemNodes, isTabActive);
+      }
+      setTreeActiveItem(activeNode);
     }
-    setTreeActiveItem(activeNode);
-  }, [isTreeNodeActive, itemNodes, isTabActive]);
+  }, [isTreeNodeActive, itemNodes, isTabActive, activePath]);
 
   const isTreeNodeExpanded = (node) =>
     !!dfs([node], (evalNode) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10586,7 +10586,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.0.11"
+    gatsby-theme-carbon: "npm:^4.1.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11887,7 +11887,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.0.11, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.1.0, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes #1511 

In Level 2 pages, tabs highlight the last menu item within the respective Level 2 section

#### Changelog

**Changed**

- Revised the logic for identifying the active menu item for the tabbed page.
- Included an example for the tabbed page in Level 2.
