### PR TITLE
fix: page description with tag spacing

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/PageDescription/PageDescription.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/PageDescription/PageDescription.module.scss
@@ -27,4 +27,5 @@ body .page-description:has(:global(.cds--tag)) {
   top: -$spacing-08;
   margin-top: 0;
   margin-bottom: 0;
+  margin-left: 0;
 }

--- a/packages/gatsby-theme-carbon/src/components/PageDescription/PageDescription.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/PageDescription/PageDescription.module.scss
@@ -8,7 +8,7 @@
 }
 
 // Multiple paragaphs
-.page-description > * + * {
+.page-description > :global(.cds--row) + * {
   margin-top: var(--space);
 }
 
@@ -18,7 +18,13 @@
 }
 
 // with tag
+body .page-description:has(:global(.cds--tag)) {
+  position: relative;
+}
+
 .page-description :global(.cds--tag) {
   position: absolute;
-  margin-top: -$spacing-09;
+  top: -$spacing-08;
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10530,7 +10530,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.1.1"
+    gatsby-theme-carbon: "npm:^4.1.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11831,7 +11831,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.1.1, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.1.2, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes #1517

![image](https://github.com/user-attachments/assets/fff5f10e-aca0-41c1-bc88-597a0c2bd247)

#### Changelog


**Changed**

- fix spacing for PageDescription with tag

https://gatsby-theme-carbon-git-fork-alison-dacea3-carbon-design-system.vercel.app/components/PageDescription/
