### PR TITLE
fix: caption spacing inside tab

### DIFF
--- a/packages/example/src/pages/components/Tabs.mdx
+++ b/packages/example/src/pages/components/Tabs.mdx
@@ -28,7 +28,9 @@ columns. If you want to have multiple columns, you’ll need to use our `Row` an
 
 If your content is full width, you don’t need `Row` and `Column`
 
-![color array](images/colors.jpg)
+![color array](./images/colors.jpg)
+
+<Caption>This is a caption</Caption>
 
 </Tab>
 

--- a/packages/gatsby-theme-carbon/src/components/Caption/Caption.module.scss
+++ b/packages/gatsby-theme-carbon/src/components/Caption/Caption.module.scss
@@ -1,6 +1,7 @@
 .caption {
   @include type-style('body-short-01');
   --space: #{$spacing-05};
+  margin-top: var(--space);
 }
 
 div .caption * {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10530,7 +10530,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.1.3"
+    gatsby-theme-carbon: "npm:^4.1.4"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11831,7 +11831,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.1.3, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.1.4, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes #1493


#### Changelog
- add correct top margin above captions

## Testing
Check captions on Tabs and Captions page. Should have 1rem top margin.