### PR TITLE
chore(fonts): update fonts to IBM Akamai urls

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-ssr.js
+++ b/packages/gatsby-theme-carbon/gatsby-ssr.js
@@ -32,7 +32,7 @@ export const onRenderBody = ({ setHeadComponents, setBodyAttributes }) => {
     <link
       key="sans"
       rel="preload"
-      href="https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman.woff2"
+      href="https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/complete/woff2/IBM%20Plex%20Sans%20Var-Roman.woff2"
       as="font"
       type="font/woff2"
       crossOrigin=""

--- a/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
@@ -9,9 +9,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin1.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin1.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin1.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin1.woff2')
       format('woff2');
   unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
     U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
@@ -23,9 +23,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin2.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin2.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin2.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
     U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
@@ -38,9 +38,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin3.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin3.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin3.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
 }
@@ -50,9 +50,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Pi.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Pi.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Pi.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Pi.woff2')
       format('woff2');
   unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
     U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,
@@ -70,9 +70,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin1.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin1.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin1.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin1.woff2')
       format('woff2');
   unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
     U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
@@ -84,9 +84,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin2.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin2.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin2.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
     U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
@@ -99,9 +99,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin3.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin3.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin3.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
 }
@@ -111,9 +111,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Pi.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Pi.woff2')
       format('woff2-variations'),
-    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Pi.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Pi.woff2')
       format('woff2');
   unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
     U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,

--- a/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
+++ b/packages/gatsby-theme-carbon/src/styles/internal/_plex.scss
@@ -9,9 +9,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin1.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin1.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin1.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin1.woff2')
       format('woff2');
   unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
     U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
@@ -23,9 +23,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin2.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin2.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin2.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
     U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
@@ -38,9 +38,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin3.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin3.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Latin3.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
 }
@@ -50,9 +50,9 @@
   font-style: normal;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Pi.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Pi.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Roman-Pi.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Roman-Pi.woff2')
       format('woff2');
   unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
     U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,
@@ -70,9 +70,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin1.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin1.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin1.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin1.woff2')
       format('woff2');
   unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
     U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
@@ -84,9 +84,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin2.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin2.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin2.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
     U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
@@ -99,9 +99,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin3.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin3.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Latin3.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
 }
@@ -111,9 +111,9 @@
   font-style: italic;
   font-weight: 100 900;
   src:
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Pi.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Pi.woff2')
       format('woff2-variations'),
-    url('https://gatsby.carbondesignsystem.com/fonts/6.3/IBMPlexSansVar-Italic-Pi.woff2')
+    url('1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM%20Plex%20Sans%20Var-Italic-Pi.woff2')
       format('woff2');
   unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
     U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,
@@ -132,7 +132,7 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono'),
-    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin1.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin1.woff2')
       format('woff2');
   unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131,
     U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E,
@@ -147,7 +147,7 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono'),
-    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin2.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin2.woff2')
       format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF,
     U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02;
@@ -160,7 +160,7 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono'),
-    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Latin3.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin3.woff2')
       format('woff2');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
@@ -172,7 +172,7 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono'),
-    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Pi.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Pi.woff2')
       format('woff2');
   unicode-range: U+0E3F, U+2032-2033, U+2070, U+2075-2079, U+2080-2081, U+2083,
     U+2085-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E,
@@ -189,7 +189,7 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono'),
-    url('https://gatsby.carbondesignsystem.com/fonts/mono/IBMPlexMono-Regular-Cyrillic.woff2')
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Cyrillic.woff2')
       format('woff2');
   unicode-range: U+0400-045F, U+0472-0473, U+0490-049D, U+04A0-04A5, U+04AA-04AB,
     U+04AE-04B3, U+04B6-04BB, U+04C0-04C2, U+04CF-04D9, U+04DC-04DF, U+04E2-04E9,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10530,7 +10530,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.1.4"
+    gatsby-theme-carbon: "npm:^4.1.5"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11831,7 +11831,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.1.4, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.1.5, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Based on a recent edge traffic report from Vercel, there has been a massive increase in traffic due to the hosting of fonts directly on Vercel. This is a pivot to move hosting to IBM Akamai instead, which can handle spikes in traffic without an incurred cost to our team.

#### Changelog

**Changed**

- Changes font domain from `gatsby.carbondesignsystem.com` to `1.www.s81c.com`
