### PR TITLE
fix(search): keyboard support for enter key

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
@@ -18,6 +18,7 @@ import { graphql, navigate, useStaticQuery } from 'gatsby';
 import cx from 'classnames';
 import NavContext from '../../util/context/NavContext';
 import { useOnClickOutside } from '../../util/hooks';
+import { convertFilePathToUrl } from '../../util/convertFilePathToUrl';
 
 import {
   container,
@@ -118,7 +119,7 @@ const GlobalSearchInput = () => {
       case 'Enter': {
         e.preventDefault();
         if (results[focusedItem]) {
-          navigate(results[focusedItem].path);
+          navigate(convertFilePathToUrl(results[focusedItem].path));
         }
         break;
       }

--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/Menu.js
@@ -14,6 +14,8 @@ import {
   tab,
 } from './GlobalSearch.module.scss';
 
+import { convertFilePathToUrl } from '../../util/convertFilePathToUrl';
+
 export const MenuContext = createContext();
 
 const Menu = ({ results, onKeyDown }) => {
@@ -76,22 +78,6 @@ const MenuItem = ({ page, index, onKeyDown, id }) => {
   const className = cx(link, {
     [active]: focusedItem === index,
   });
-
-  function convertFilePathToUrl(filePath) {
-    const pagesIndex = filePath.lastIndexOf('/pages/');
-    if (filePath.lastIndexOf('/pages/') === -1) return null;
-
-    const fileName = filePath.slice(
-      pagesIndex + '/pages/'.length,
-      -'.mdx'.length
-    );
-    const normalizedFileName = fileName.endsWith('/index')
-      ? fileName.slice(0, -'/index'.length)
-      : fileName;
-    const urlPath = `/${normalizedFileName.split('/').join('/')}/`;
-
-    return urlPath;
-  }
 
   const url = convertFilePathToUrl(page.path);
 

--- a/packages/gatsby-theme-carbon/src/util/convertFilePathToUrl.js
+++ b/packages/gatsby-theme-carbon/src/util/convertFilePathToUrl.js
@@ -1,0 +1,18 @@
+// utils/convertFilePathToUrl.js
+export function convertFilePathToUrl(filePath) {
+  if (!filePath) return null;
+
+  const pagesIndex = filePath.lastIndexOf('/pages/');
+  if (pagesIndex === -1) return null;
+
+  const fileName = filePath.slice(
+    pagesIndex + '/pages/'.length,
+    filePath.lastIndexOf('.')
+  );
+  const normalizedFileName = fileName.endsWith('/index')
+    ? fileName.slice(0, -'/index'.length)
+    : fileName;
+  const urlPath = `/${normalizedFileName}/`;
+
+  return urlPath;
+}

--- a/packages/gatsby-theme-carbon/src/util/convertFilePathToUrl.js
+++ b/packages/gatsby-theme-carbon/src/util/convertFilePathToUrl.js
@@ -1,4 +1,3 @@
-// utils/convertFilePathToUrl.js
 export function convertFilePathToUrl(filePath) {
   if (!filePath) return null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10135,7 +10135,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.1.12"
+    gatsby-theme-carbon: "npm:^4.1.13"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11436,7 +11436,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.1.12, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.1.13, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes #1524

Fix so enter key 

#### Changelog
- moved convertFilePathToUrl out of Menu and into utilites folder
- convert the file path to url when hitting the enter key for GlobalSearch

#### Testing
Search for something that has results and hit enter, it should navigate the first item selected in the results list, or the item you have navigated to by keyboard. 