### PR TITLE
chore(npm): publish packages with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Needed as recommended by npm docs on publishing with provenance https://docs.npmjs.com/generating-provenance-statements
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "validate": "yarn format:ci && yarn lint"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "access": "public",
+    "provenance": true
   },
   "release-it": {
     "plugins": {

--- a/packages/gatsby-theme-carbon/package.json
+++ b/packages/gatsby-theme-carbon/package.json
@@ -8,7 +8,8 @@
     "type": "git"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "access": "public",
+    "provenance": true
   },
   "license": "Apache 2.0",
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10117,7 +10117,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.43.0"
     gatsby: "npm:^5.13.6"
-    gatsby-theme-carbon: "npm:^4.1.21"
+    gatsby-theme-carbon: "npm:^4.2.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11403,7 +11403,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.1.21, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.2.0, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/1369

Update to publish with provenance
https://docs.npmjs.com/generating-provenance-statements

mirrored what was done for core Carbon https://github.com/carbon-design-system/carbon/pull/14344

#### Changelog

**New**

- add provenance: true to publishConfig in package.json files



**Changed**

- update publish workflows to have proper permissions per the npm docs

**Removed**

- remove registry from package.json, should not be needed as its the default
