### PR TITLE
fix: allow multiple medium accounts

### DIFF
--- a/packages/gatsby-theme-carbon/gatsby-config.mjs
+++ b/packages/gatsby-theme-carbon/gatsby-config.mjs
@@ -57,12 +57,17 @@ export default (themeOptions) => {
   const optionalPlugins = [];
 
   if (mediumAccount) {
-    optionalPlugins.push({
-      resolve: 'gatsby-source-medium-feed',
-      options: {
-        userName: mediumAccount, // Medium user name
-        name: 'MediumFeed',
-      },
+    const accounts = Array.isArray(mediumAccount)
+      ? mediumAccount
+      : [mediumAccount];
+    accounts.forEach((account) => {
+      optionalPlugins.push({
+        resolve: 'gatsby-source-medium-feed',
+        options: {
+          userName: account, // Medium user name
+          name: 'MediumFeed',
+        },
+      });
     });
   }
 


### PR DESCRIPTION
Closes #4476 from Carbon-Website

Updated the gatsby-config function to support multiple Medium accounts by accepting an array of strings as well.
