### PR TITLE
chore: update validate workflow ubuntu version

### DIFF
--- a/.github/workflows/validate-and-build.yaml
+++ b/.github/workflows/validate-and-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-and-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10386,7 +10386,7 @@ __metadata:
   dependencies:
     "@carbon/icons-react": "npm:^11.54.0"
     gatsby: "npm:^5.14.1"
-    gatsby-theme-carbon: "npm:^4.2.14"
+    gatsby-theme-carbon: "npm:^4.2.15"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
   languageName: unknown
@@ -11718,7 +11718,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"gatsby-theme-carbon@npm:^4.2.14, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
+"gatsby-theme-carbon@npm:^4.2.15, gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon":
   version: 0.0.0-use.local
   resolution: "gatsby-theme-carbon@workspace:packages/gatsby-theme-carbon"
   dependencies:


### PR DESCRIPTION
Update the ubuntu version to `ubuntu-latest` as the [`Ubuntu 20.04` runner image is no longer supported](https://github.com/actions/runner-images/issues/11101).

#### Changelog

**Changed**

- update the validate-and-build GitHub Action workflow to use `ubuntu-latest`
