### PR TITLE
fix(globalsearch): tweak regex to properly replace

### DIFF
--- a/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
+++ b/packages/gatsby-theme-carbon/src/components/GlobalSearch/GlobalSearch.js
@@ -56,7 +56,7 @@ const GlobalSearchInput = () => {
 
   const sanitizeQuery = (str) => {
     // Escape special characters to prevent queryParseError
-    return str.replace(/[`~!@#$%^&*()\-_=+\[\]{}\\|;:'",<.>/?]/g, '\\$1');
+    return str.replace(/[`~!@#$%^&*()\-_=+\[\]{}\\|;:'",<.>/?]/g, '\\$&');
   };
 
   const results = useLunr(sanitizeQuery(query), index, store);


### PR DESCRIPTION
No issue

Fixes the regex for globalSearch `sanitizeQuery` function to properly replace special characters

#### Changelog


**Changed**

- Changed `\\$1` to `\\$&`

