### PR TITLE
fix(actions): git actions version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache 2.0",
   "engines": {
-    "node": "20.x || 22.x"
+    "node": "20.x || 22.2.1"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Closes #

Updated the node version to `"node": "20.x || 22.2.1"` in package.json as a workaround to the action issue caused by:  https://github.com/actions/runner-images/issues/13883

#### Changelog

**Changed**

- Updated the node version to "node": "20.x || 22.2.1" 

