### PR TITLE
fix(actions): regression work around

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.2.1'
+          node-version: '22.21.1'
           cache: 'yarn'
 
       - name: Setup Pages

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.2.1'
           cache: 'yarn'
 
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.2.1'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.2.1'
+          node-version: '22.21.1'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/validate-and-build.yaml
+++ b/.github/workflows/validate-and-build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.2.1'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/validate-and-build.yaml
+++ b/.github/workflows/validate-and-build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.2.1'
+          node-version: '22.21.1'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache 2.0",
   "engines": {
-    "node": "20.x || 22.2.1"
+    "node": "20.x || 22.x"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Closes #

Updated the workflow files to specifically use `22.2.1` as a workaround to the action issue caused by:  https://github.com/actions/runner-images/issues/13883

#### Changelog

**Changed**

- Updated the workflow files to specifically use `22.2.1`

