### PR TITLE
fix(actions): revert node version pin back to 22

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.21.1'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.21.1'
+          node-version: '22'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/validate-and-build.yaml
+++ b/.github/workflows/validate-and-build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.21.1'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
Closes #

Reverts the temporary Node.js version pin introduced in #1699 across all workflow files.

#### Changelog

**Changed**

- Updated the workflow files to use 22 instead of 22.2.1 specifically.

